### PR TITLE
core: use TextMergeViewer for presenting differences between revisions

### DIFF
--- a/de.setsoftware.reviewtool.core/META-INF/MANIFEST.MF
+++ b/de.setsoftware.reviewtool.core/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.106.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.4.0,2.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.106.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.9.0,4.0.0)",
- org.eclipse.equinox.security;bundle-version="[1.2.0,2.0.0)"
+ org.eclipse.equinox.security;bundle-version="[1.2.0,2.0.0)",
+ org.eclipse.compare;bundle-version="[3.5.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: minimal-json.jar,
  antlr-runtime-3.4.jar,

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/StopInfoView.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/StopInfoView.java
@@ -1,14 +1,16 @@
 package de.setsoftware.reviewtool.ui.views;
 
+import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
+import org.eclipse.compare.structuremergeviewer.DiffNode;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.part.ViewPart;
 
@@ -54,50 +56,64 @@ public class StopInfoView extends ViewPart implements StopSelectionListener {
 
         final Composite scrollContent = new Composite(scroll, SWT.NULL);
 
-        final GridLayout layout = new GridLayout();
-        layout.numColumns = fragment.getHistory().size();
+        final FillLayout layout = new FillLayout();
         scrollContent.setLayout(layout);
 
-        for (final FileInRevision revision : fragment.getHistory()) {
-            final Label revLabel = new Label(scrollContent, SWT.NULL);
-            revLabel.setText("Rev. " + revision.getRevision().toString());
-            revLabel.setToolTipText(revision.getPath());
-            ViewHelper.createContextMenuWithoutSelectionProvider(this, revLabel);
-        }
-
-        for (final FileInRevision revision : fragment.getHistory()) {
-            this.createContentLabel(scrollContent, fragment.getContentFor(revision));
+        final Iterator<FileInRevision> it = fragment.getHistory().iterator();
+        FileInRevision oldRevision = null;
+        while (it.hasNext()) {
+            final FileInRevision newRevision = it.next();
+            if (oldRevision != null) {
+                this.createContentLabel(scrollContent, fragment, oldRevision, newRevision);
+                oldRevision = null;
+            } else {
+                oldRevision = newRevision;
+            }
         }
 
         scroll.setContent(scrollContent);
         return scroll;
     }
 
-    private void createContentLabel(Composite scrollContent, List<Fragment> content) {
-        final Label label;
-        if (content == null) {
-            label = new Label(scrollContent, SWT.NULL);
+    /**
+     * Builds a string containing the concatenated contents of the fragments passed.
+     * @param fragments The list of fragments.
+     * @return The concatenated contents of the fragments passed.
+     */
+    private String mapFragmentsToString(final List<Fragment> fragments) {
+        final StringBuilder text = new StringBuilder();
+        boolean first = true;
+        for (final Fragment f : fragments) {
+            if (first) {
+                first = false;
+            } else {
+                text.append("\n...\n\n");
+            }
+            text.append(f.getContent());
+        }
+        return text.toString();
+    }
+
+    private void createContentLabel(final Composite scrollContent, final Stop fragment,
+            final FileInRevision oldRevision, final FileInRevision newRevision) {
+        final List<Fragment> oldContent = fragment.getContentFor(oldRevision);
+        final List<Fragment> newContent = fragment.getContentFor(newRevision);
+        if (oldContent == null || newContent == null) {
+            final Label label = new Label(scrollContent, SWT.NULL);
             label.setText("binary");
             label.setFont(
                     JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT));
+            ViewHelper.createContextMenuWithoutSelectionProvider(this, label);
         } else {
-            label = new Label(scrollContent, SWT.BORDER);
-            final StringBuilder text = new StringBuilder();
-            boolean first = true;
-            for (final Fragment f : content) {
-                if (first) {
-                    first = false;
-                } else {
-                    text.append("\n...\n\n");
-                }
-                text.append(f.getContent());
-            }
-            label.setText(text.toString());
-            label.setFont(
-                    JFaceResources.getFontRegistry().get(JFaceResources.TEXT_FONT));
-            label.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
+            final CompareConfiguration compareConfiguration = new CompareConfiguration();
+            compareConfiguration.setLeftLabel(oldRevision.toString());
+            compareConfiguration.setRightLabel(newRevision.toString());
+            final TextMergeViewer viewer = new TextMergeViewer(scrollContent, SWT.BORDER, compareConfiguration);
+            viewer.setInput(new DiffNode(new TextItem(oldRevision.toString(), this.mapFragmentsToString(oldContent),
+                    System.currentTimeMillis()),
+                    new TextItem(newRevision.toString(), this.mapFragmentsToString(newContent),
+                            System.currentTimeMillis())));
         }
-        ViewHelper.createContextMenuWithoutSelectionProvider(this, label);
     }
 
     private Composite createIdleContent(String text) {

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/TextItem.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/TextItem.java
@@ -1,0 +1,65 @@
+package de.setsoftware.reviewtool.ui.views;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import org.eclipse.compare.IEncodedStreamContentAccessor;
+import org.eclipse.compare.IModificationDate;
+import org.eclipse.compare.ITypedElement;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.swt.graphics.Image;
+
+/**
+ * Encapsulates string input for the TextMergeViewer.
+ */
+public class TextItem implements IEncodedStreamContentAccessor, ITypedElement, IModificationDate {
+
+    private final String name;
+    private final String contents;
+    private final long modificationTime;
+    private final Charset charset = Charset.forName("UTF-8"); //$NON-NLS-1$
+
+    /**
+     * Constructs a TextItem.
+     * @param name The name of the TextItem.
+     * @param contents The contents of the TextItem.
+     * @param modificationTime The modification time of the TextItem in milliseconds since epoch.
+     */
+    public TextItem(final String name, final String contents, final long modificationTime) {
+        this.name = name;
+        this.contents = contents;
+        this.modificationTime = modificationTime;
+    }
+
+    @Override
+    public long getModificationDate() {
+        return this.modificationTime;
+    }
+
+    @Override
+    public Image getImage() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getType() {
+        return ITypedElement.TEXT_TYPE;
+    }
+
+    @Override
+    public InputStream getContents() throws CoreException {
+        return new ByteArrayInputStream(this.contents.getBytes(this.charset));
+    }
+
+    @Override
+    public String getCharset() throws CoreException {
+        return this.charset.name();
+    }
+
+}


### PR DESCRIPTION
This changeset changes the presentation of differences between
revisions. Now the TextMergeViewer class is used which provides a more
comprehensible (and familiar) UI interface.

Signed-off-by: Christoph Schulz develop@kristov.de
