### PR TITLE
svn: handle checkouts of multiple branches

### DIFF
--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnChangeSource.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnChangeSource.java
@@ -191,9 +191,12 @@ public class SvnChangeSource implements IChangeSource {
                     workingCopyRoot,
                     rootUrl,
                     this.determineCheckoutPrefix(workingCopyRoot, rootUrl)));
+
+            final SVNURL wcUrl = this.mgr.getWCClient().doInfo(workingCopyRoot, SVNRevision.WORKING).getURL();
+            final String relPath = wcUrl.toString().substring(rootUrl.toString().length());
             this.mgr.getLogClient().doLog(
                     rootUrl,
-                    new String[] {"/"},
+                    new String[] { relPath },
                     SVNRevision.HEAD,
                     SVNRevision.HEAD,
                     SVNRevision.create(0),


### PR DESCRIPTION
If the user checks out multiple branches of the same repository, the
commit detection code is confused because the same commit is associated
with all checkouts, even if it refers only files from a single checkout.
This is because the log action does not filter wrt. the repository URLs
of the working directories. This changeset makes the log action consider
the working directory's repository URL.
