### PR TITLE
ui: do not allow to mark tours as explicitly checked

### DIFF
--- a/de.setsoftware.reviewtool.core/plugin.xml
+++ b/de.setsoftware.reviewtool.core/plugin.xml
@@ -113,13 +113,18 @@
                </with>
              </visibleWhen>
 	   </command>
-	   <command commandId="de.setsoftware.reviewtool.commands.markAsChecked"
-	   		 label="Mark/Unmark explicitly checked" 
-	   		 style="push">
-	   		 <!--<visibleWhen>
-               <adapt type="de.setsoftware.reviewtool.model.changestructure.Stop" />
-             </visibleWhen>-->
-	   </command>
+       <command commandId="de.setsoftware.reviewtool.commands.markAsChecked"
+             label="Mark/Unmark explicitly checked"
+             style="push">
+             <visibleWhen>
+               <with variable="activeMenuSelection">
+                 <count value="+"/>
+                 <iterate>
+                   <adapt type="de.setsoftware.reviewtool.model.changestructure.Stop" />
+                 </iterate>
+               </with>
+             </visibleWhen>
+       </command>
 	 </menuContribution>
    </extension>
    <extension point="org.eclipse.ui.commands">


### PR DESCRIPTION
This changeset prevents the user from marking a tour as explicitly
checked, as this breaks MarkAsCheckedAction.execute() which assumes a
list of Stops and fails with a ClassCastException otherwise.

As a by-product, the change enables the user to mark multiple Stops as
explicitly checked at once.
