### PR TITLE
tourrestructuring: fix merging of stops

### DIFF
--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/tourrestructuring/onestop/MutableTour.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/tourrestructuring/onestop/MutableTour.java
@@ -88,12 +88,21 @@ class MutableTour implements IReviewElement {
     }
 
     private StopInTour getStopToMergeWith(Stop s, List<MutableTour> mutableTours, int excludedIndex) {
+        // try to merge with stops of later tours
         for (int tourIndex = excludedIndex + 1; tourIndex < mutableTours.size(); tourIndex++) {
             final StopInTour mergeWith = mutableTours.get(tourIndex).getStopToMergeWith(s);
             if (mergeWith != null) {
                 return mergeWith;
             }
         }
+        // try to merge with stops in this tour
+        {
+            final StopInTour mergeWith = mutableTours.get(excludedIndex).getStopToMergeWith(s);
+            if (mergeWith != null) {
+                return mergeWith;
+            }
+        }
+        // try to merge with stops of earlier tours (only necessary for resolving complete tours)
         for (int tourIndex = excludedIndex - 1; tourIndex >= 0; tourIndex--) {
             final StopInTour mergeWith = mutableTours.get(tourIndex).getStopToMergeWith(s);
             if (mergeWith != null) {
@@ -105,7 +114,8 @@ class MutableTour implements IReviewElement {
 
     private StopInTour getStopToMergeWith(Stop s) {
         for (int stopIndex = 0; stopIndex < this.stops.size(); stopIndex++) {
-            if (this.stops.get(stopIndex).canBeMergedWith(s)) {
+            final Stop stop = this.stops.get(stopIndex);
+            if (!s.equals(stop) && stop.canBeMergedWith(s)) {
                 return new StopInTour(this, stopIndex);
             }
         }


### PR DESCRIPTION
The current algorithm does not merge all possible stops. Consider the
situation where in tour T1 a stop S1 creates a file F, and in tour T2
three stops S2, S3, and S4 modify that file F. While analysing, S1 is
determined to be mergeable with S2. The algorithm stores the merge
result S2' in T2/S2 (overwriting the old stop S2) and removes the stop
S1 from Tour T1. But the algorithm never considers whether the new
merged stop S2' can be merged with S3 or S4, because they are in the
same tour T2.

This changeset fixes this problem by also checking whether stops in the
same tour can be merged (preventing a stop from being merged with
itself).
