### PR TITLE
CombinedDiffStopViewer: handle binary changes properly

### DIFF
--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
@@ -45,7 +45,7 @@ public class CombinedDiffStopViewer extends AbstractStopViewer {
 
             final List<Fragment> fragmentsFirst = stop.getContentFor(firstRevision);
             final List<Fragment> fragmentsLast = stop.getContentFor(lastRevision);
-            if (fragmentsFirst == null || fragmentsLast == null) { // binary change
+            if (fragmentsFirst.isEmpty() || fragmentsLast.isEmpty()) { // binary change
                 this.createDiffViewer(view, scrollContent, firstRevision, lastRevision, fragmentsFirst, fragmentsLast,
                         null, null);
             } else { // textual change


### PR DESCRIPTION
When a binary file is changed, the fragment lists returned by
Stop.getContentFor() are not null but empty. This commit corrects the
checks accordingly.