### PR TITLE
Fix make FileDiff aware of revision range

### DIFF
--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
@@ -343,7 +343,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
                     true,   // must not exist
                     false,  // is not known to be a new node
                     false); // don't copy children (they do not exist anyway)
-            ancestor.addDescendant(node, new FileDiff(prevFile));
+            ancestor.addDescendant(node, new FileDiff(prevFile, file));
         }
     }
 
@@ -367,7 +367,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
         this.addParentNodes(deletionNode, true, false);
         final Pair<String, Repository> key = this.createKey(file);
         this.index.put(key, deletionNode);
-        oldNode.addDescendant(deletionNode, new FileDiff(previousFile));
+        oldNode.addDescendant(deletionNode, new FileDiff(previousFile, file));
 
         for (final SvnFileHistoryNode child : oldNode.getChildren()) {
             this.addDeletion(child.getFile().getPath(), prevRevision, revision, repo);
@@ -400,7 +400,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
      */
     private void addEdge(final ExistingFileHistoryNode ancestor, final SvnFileHistoryNode descendant,
             final boolean copyChildren) {
-        ancestor.addDescendant(descendant, new FileDiff(descendant.getFile()));
+        ancestor.addDescendant(descendant, new FileDiff(ancestor.getFile(), descendant.getFile()));
         if (copyChildren) {
             this.copyChildNodes(ancestor, descendant);
         }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
@@ -107,7 +107,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
         @Override
         public FileDiff buildHistory(final FileHistoryNode from) {
             if (from.equals(this)) {
-                return new FileDiff();
+                return new FileDiff(from.getFile());
             }
 
             if (this.ancestor == null) {
@@ -343,7 +343,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
                     true,   // must not exist
                     false,  // is not known to be a new node
                     false); // don't copy children (they do not exist anyway)
-            ancestor.addDescendant(node, new FileDiff());
+            ancestor.addDescendant(node, new FileDiff(prevFile));
         }
     }
 
@@ -367,7 +367,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
         this.addParentNodes(deletionNode, true, false);
         final Pair<String, Repository> key = this.createKey(file);
         this.index.put(key, deletionNode);
-        oldNode.addDescendant(deletionNode, new FileDiff());
+        oldNode.addDescendant(deletionNode, new FileDiff(previousFile));
 
         for (final SvnFileHistoryNode child : oldNode.getChildren()) {
             this.addDeletion(child.getFile().getPath(), prevRevision, revision, repo);
@@ -400,7 +400,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
      */
     private void addEdge(final ExistingFileHistoryNode ancestor, final SvnFileHistoryNode descendant,
             final boolean copyChildren) {
-        ancestor.addDescendant(descendant, new FileDiff());
+        ancestor.addDescendant(descendant, new FileDiff(descendant.getFile()));
         if (copyChildren) {
             this.copyChildNodes(ancestor, descendant);
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
@@ -20,7 +20,7 @@ public class FileDiff {
     private FileInRevision toRevision;
 
     /**
-     * Creates an empty FileDiff object.
+     * Creates an empty FileDiff object that will be filled with hunks.
      */
     public FileDiff(final FileInRevision revision) {
         this.hunks = new ArrayList<>();
@@ -31,8 +31,17 @@ public class FileDiff {
     /**
      * Creates a FileDiff object that will be filled with hunks.
      */
-    private FileDiff(final FileInRevision fromRevision, final FileInRevision toRevision) {
+    public FileDiff(final FileInRevision fromRevision, final FileInRevision toRevision) {
         this.hunks = new ArrayList<>();
+        this.fromRevision = fromRevision;
+        this.toRevision = toRevision;
+    }
+
+    /**
+     * Creates a fully specified FileDiff object.
+     */
+    private FileDiff(final FileInRevision fromRevision, final FileInRevision toRevision, final List<Hunk> hunks) {
+        this.hunks = new ArrayList<>(hunks);
         this.fromRevision = fromRevision;
         this.toRevision = toRevision;
     }
@@ -59,6 +68,16 @@ public class FileDiff {
         return this.toRevision;
     }
 
+    /**
+     * Creates a copy of this object with a new target revision. The list of hunks is copied in such a way that
+     * both lists can be modified separately after the copy.
+     *
+     * @param newTo The new target revision.
+     * @return The requested copy.
+     */
+    public FileDiff setTo(final FileInRevision newTo) {
+        return new FileDiff(this.fromRevision, newTo, this.hunks);
+    }
     /**
      * Traces a source fragment over the recorded hunks to the last known file revision.
      * @param source The source fragment.
@@ -177,7 +196,7 @@ public class FileDiff {
      * @throws IncompatibleFragmentException if some hunk to be merged overlaps with some hunk in the FileDiff object.
      */
     public FileDiff merge(final FileDiff diff) throws IncompatibleFragmentException {
-        return this.merge(diff.hunks);
+        return this.merge(diff.hunks).setTo(diff.toRevision);
     }
 
     private boolean containsInLineDiff(Hunk hunk) {

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
@@ -64,7 +64,7 @@ public class FileDiff {
      * @param source The source fragment.
      * @return The resulting fragment matching the last known file revision.
      */
-    public Fragment traceFragment(Fragment source) {
+    public Fragment traceFragment(final Fragment source) {
         final List<Hunk> hunks = new ArrayList<Hunk>();
         for (final Hunk hunk : this.hunks) {
             if (hunk.getSource().overlaps(source)) {
@@ -74,7 +74,7 @@ public class FileDiff {
             }
         }
         try {
-            return this.createCombinedFragment(hunks, source);
+            return this.createCombinedFragment(hunks, source).setFile(this.toRevision);
         } catch (final IncompatibleFragmentException e) {
             throw new Error(e);
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Fragment.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Fragment.java
@@ -221,6 +221,15 @@ public class Fragment implements Comparable<Fragment> {
         return this.to.lessThan(this.from);
     }
 
+    /**
+     * Creates a fragment whose file is set to the one passed.
+     * @param newFile The {@link FileInRevision} to use.
+     * @return The resulting fragment.
+     */
+    Fragment setFile(final FileInRevision newFile) {
+        return new Fragment(newFile, this.from, this.to);
+    }
+
     @Override
     public int hashCode() {
         return this.from.hashCode() + 31 * this.file.hashCode();

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
@@ -152,6 +152,24 @@ public class Hunk {
     }
 
     /**
+     * Creates a new hunk whose source fragment's file is set to the one passed.
+     * @param source The {@link FileInRevision} to use.
+     * @return The resulting hunk.
+     */
+    Hunk adjustSourceFile(final FileInRevision source) {
+        return new Hunk(this.source.setFile(source), this.target);
+    }
+
+    /**
+     * Creates a new hunk whose target fragment's file is set to the one passed.
+     * @param source The {@link FileInRevision} to use.
+     * @return The resulting hunk.
+     */
+    Hunk adjustTargetFile(final FileInRevision target) {
+        return new Hunk(this.source, this.target.setFile(target));
+    }
+
+    /**
      * Returns the negative delta of this hunk if passed position is behind this hunk. This is helpful if some given
      * position has to be adjusted by "counting away" this hunk.
      * @param pos The position in question.

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -201,7 +201,7 @@ public class FileDiffTest {
         final FileInRevision f2 = file("a.java", 2);
         final FileInRevision f3 = file("a.java", 3);
 
-        final FileDiff diff = new FileDiff().merge(new Hunk(
+        final FileDiff diff = new FileDiff(f1).merge(new Hunk(
                 new Fragment(f2, pos(5, 1), pos(5, 0)),
                 new Fragment(f3, pos(5, 1), pos(6, 0))));
 
@@ -228,7 +228,7 @@ public class FileDiffTest {
         final FileInRevision f2 = file("a.java", 2);
         final FileInRevision f3 = file("a.java", 3);
 
-        final FileDiff diff = new FileDiff().merge(new Hunk(
+        final FileDiff diff = new FileDiff(f1).merge(new Hunk(
                 new Fragment(f2, pos(5, 10), pos(5, 14)),
                 new Fragment(f3, pos(5, 10), pos(5, 14))));
 
@@ -265,7 +265,7 @@ public class FileDiffTest {
         final FileInRevision f3 = file("a.java", 3);
         final FileInRevision f4 = file("a.java", 4);
 
-        final FileDiff diff = new FileDiff()
+        final FileDiff diff = new FileDiff(f1)
                 .merge(new Hunk(
                     new Fragment(f2, pos(5, 7), pos(5, 6)),
                     new Fragment(f3, pos(5, 7), pos(5, 8))))

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -206,19 +206,18 @@ public class FileDiffTest {
                 new Fragment(f3, pos(5, 1), pos(6, 0))));
 
         final Fragment actual1 = diff.traceFragment(new Fragment(f1, pos(1, 1), pos(2, 0)));
-        //TODO shouldn't the resulting fragment have file revision 3 (and not 1)? applies to other tests, too.
         assertEquals(
-                new Fragment(f1, pos(1, 1), pos(2, 0)),
+                new Fragment(f3, pos(1, 1), pos(2, 0)),
                 actual1);
 
         final Fragment actual2 = diff.traceFragment(new Fragment(f1, pos(7, 1), pos(9, 0)));
         assertEquals(
-                new Fragment(f1, pos(8, 1), pos(10, 0)),
+                new Fragment(f3, pos(8, 1), pos(10, 0)),
                 actual2);
 
         final Fragment actual3 = diff.traceFragment(new Fragment(f1, pos(2, 1), pos(7, 0)));
         assertEquals(
-                new Fragment(f1, pos(2, 1), pos(8, 0)),
+                new Fragment(f3, pos(2, 1), pos(8, 0)),
                 actual3);
     }
 
@@ -235,19 +234,19 @@ public class FileDiffTest {
         final Fragment actual1 = diff.traceFragment(
                 new Fragment(f1, pos(1, 1), pos(2, 0)));
         assertEquals(
-                new Fragment(f1, pos(1, 1), pos(2, 0)),
+                new Fragment(f3, pos(1, 1), pos(2, 0)),
                 actual1);
 
         final Fragment actual2 = diff.traceFragment(
                 new Fragment(f1, pos(7, 1), pos(9, 0)));
         assertEquals(
-                new Fragment(f1, pos(7, 1), pos(9, 0)),
+                new Fragment(f3, pos(7, 1), pos(9, 0)),
                 actual2);
 
         final Fragment actual3 = diff.traceFragment(
                 new Fragment(f1, pos(2, 1), pos(7, 0)));
         assertEquals(
-                new Fragment(f1, pos(2, 1), pos(7, 0)),
+                new Fragment(f3, pos(2, 1), pos(7, 0)),
                 actual3);
 
         final Fragment actual4 = diff.traceFragment(

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
@@ -12,8 +12,8 @@ import org.junit.Test;
  */
 public class HunkMergeTest {
 
-    private static FileInRevision file() {
-        return new FileInRevision("file", new LocalRevision(), StubRepo.INSTANCE);
+    private static FileInRevision file(final int revision) {
+        return new FileInRevision("file", new RepoRevision(revision), StubRepo.INSTANCE);
     }
 
     private static PositionInText pos(int line, int col) {
@@ -22,193 +22,280 @@ public class HunkMergeTest {
 
     @Test
     public void testMergeSingleAdditionOnEmptyHunkList1() throws IncompatibleFragmentException {
-        final FileDiff list = new FileDiff();
-        final Hunk hunk = new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(1, 0)));
-        final FileDiff mergedList = list.merge(hunk);
+        final FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(1, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(hunk);
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(2), pos(1, 1), pos(1, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
-    public void testMergeSingleAdditionOnEmptyHunkList12() throws IncompatibleFragmentException {
-        final FileDiff list = new FileDiff();
-        final Hunk hunk = new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0)));
-        final FileDiff mergedList = list.merge(hunk);
+    public void testMergeSingleAdditionOnEmptyHunkList2() throws IncompatibleFragmentException {
+        final FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(hunk);
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(2), pos(1, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
-    public void testMergeSingleAdditionOnEmptyHunkList13() throws IncompatibleFragmentException {
-        final FileDiff list = new FileDiff();
-        final Hunk hunk = new Hunk(new Fragment(file(), pos(5, 1), pos(5, 0)),
-                new Fragment(file(), pos(5, 1), pos(7, 0)));
-        final FileDiff mergedList = list.merge(hunk);
+    public void testMergeSingleAdditionOnEmptyHunkList3() throws IncompatibleFragmentException {
+        final FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(5, 1), pos(5, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(5, 1), pos(7, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(hunk);
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(2), pos(5, 1), pos(7, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleAdditionOnNonEmptyHunkList1() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(2, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(2, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(3), pos(2, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleAdditionOnNonEmptyHunkList2() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(1, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(2, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev2.setFile(file(1)),
+                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(2, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleAdditionOnNonEmptyHunkList3() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(3, 1), pos(3, 0)),
-                new Fragment(file(), pos(3, 1), pos(4, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(3, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(4, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(2, 1), pos(2, 0)),
-                new Fragment(file(), pos(3, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(2, 1), pos(2, 0)),
+                new Fragment(file(3), pos(3, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSinglePartlyOverlappingChange1() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(3, 0)),
-                new Fragment(file(), pos(2, 1), pos(4, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(3, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(4, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSinglePartlyOverlappingChange2() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(2, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                targetRev2));
+
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(
+                new Fragment(file(2), pos(1, 1), pos(2, 0)),
+                targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(3), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleFullyOverlappingChange() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(2, 0)),
-                new Fragment(file(), pos(2, 1), pos(5, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(6, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(2, 1), pos(2, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(2, 1), pos(5, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(6, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(3, 0)),
+                new Fragment(file(3), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleMultiplyOverlappingChange1() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(4, 1), pos(4, 0)),
-                new Fragment(file(), pos(4, 1), pos(6, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(5, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 0));
+        list = list.merge(new Hunk(sourceRev2, targetRev3));
+
+        final Fragment sourceRev3 = new Fragment(file(3), pos(2, 1), pos(5, 0));
+        final Fragment targetRev4 = new Fragment(file(4), pos(2, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev3, targetRev4));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(2, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(2, 0)),
+                new Fragment(file(4), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
 
     @Test
     public void testMergeSingleMultiplyOverlappingChange2() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(4, 1), pos(4, 0)),
-                new Fragment(file(), pos(4, 1), pos(6, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(7, 1), pos(7, 0)),
-                new Fragment(file(), pos(7, 1), pos(9, 0))));
-        final FileDiff mergedList =
-                list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(8, 0)),
-                        new Fragment(file(), pos(2, 1), pos(5, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 0));
+        list = list.merge(new Hunk(sourceRev2, targetRev3));
+
+        final Fragment sourceRev3 = new Fragment(file(3), pos(7, 1), pos(7, 0));
+        final Fragment targetRev4 = new Fragment(file(4), pos(7, 1), pos(9, 0));
+        list = list.merge(new Hunk(sourceRev3, targetRev4));
+
+        final Fragment sourceRev4 = new Fragment(file(4), pos(2, 1), pos(8, 0));
+        final Fragment targetRev5 = new Fragment(file(5), pos(2, 1), pos(5, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev4, targetRev5));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(6, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(3, 0)),
+                new Fragment(file(5), pos(1, 1), pos(6, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeAdditionAndDeletion() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(3, 1), pos(5, 0)),
-                new Fragment(file(), pos(3, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 0));
+        list = list.merge(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                targetRev2));
+
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 0));
+        list = list.merge(new Hunk(
+                new Fragment(file(2), pos(1, 1), pos(3, 0)),
+                targetRev3));
+
+        final Fragment targetRev4 = new Fragment(file(4), pos(3, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(
+                new Fragment(file(3), pos(3, 1), pos(5, 0)),
+                targetRev4));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(4), pos(1, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeChangeAndDeletion() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(3, 1), pos(5, 0)),
-                new Fragment(file(), pos(3, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(3, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(5, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(4, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(4, 0)),
+                new Fragment(file(3), pos(1, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 }


### PR DESCRIPTION
Until now, FileDiffs were not aware of their revision range, and the Hunks they were composed of could refer to different and incompatible FileInRevision objects, as the underlying Hunk and Fragment manipulations are agnostic of FileInRevisions.This changeset attaches source and target FileInRevision objects to a FileDiff, making it aware of the revision range, such that the correct FileInRevisions can be attached to Fragments (e.g. when being moved, enlarged, or traced).