### PR TITLE
Fix combined diffs for inline hunks and merged stops

### DIFF
--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
@@ -343,7 +343,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
                     true,   // must not exist
                     false,  // is not known to be a new node
                     false); // don't copy children (they do not exist anyway)
-            ancestor.addDescendant(node, new FileDiff(prevFile));
+            ancestor.addDescendant(node, new FileDiff(prevFile, file));
         }
     }
 
@@ -367,7 +367,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
         this.addParentNodes(deletionNode, true, false);
         final Pair<String, Repository> key = this.createKey(file);
         this.index.put(key, deletionNode);
-        oldNode.addDescendant(deletionNode, new FileDiff(previousFile));
+        oldNode.addDescendant(deletionNode, new FileDiff(previousFile, file));
 
         for (final SvnFileHistoryNode child : oldNode.getChildren()) {
             this.addDeletion(child.getFile().getPath(), prevRevision, revision, repo);
@@ -400,7 +400,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
      */
     private void addEdge(final ExistingFileHistoryNode ancestor, final SvnFileHistoryNode descendant,
             final boolean copyChildren) {
-        ancestor.addDescendant(descendant, new FileDiff(descendant.getFile()));
+        ancestor.addDescendant(descendant, new FileDiff(ancestor.getFile(), descendant.getFile()));
         if (copyChildren) {
             this.copyChildNodes(ancestor, descendant);
         }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
@@ -107,7 +107,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
         @Override
         public FileDiff buildHistory(final FileHistoryNode from) {
             if (from.equals(this)) {
-                return new FileDiff();
+                return new FileDiff(from.getFile());
             }
 
             if (this.ancestor == null) {
@@ -343,7 +343,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
                     true,   // must not exist
                     false,  // is not known to be a new node
                     false); // don't copy children (they do not exist anyway)
-            ancestor.addDescendant(node, new FileDiff());
+            ancestor.addDescendant(node, new FileDiff(prevFile));
         }
     }
 
@@ -367,7 +367,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
         this.addParentNodes(deletionNode, true, false);
         final Pair<String, Repository> key = this.createKey(file);
         this.index.put(key, deletionNode);
-        oldNode.addDescendant(deletionNode, new FileDiff());
+        oldNode.addDescendant(deletionNode, new FileDiff(previousFile));
 
         for (final SvnFileHistoryNode child : oldNode.getChildren()) {
             this.addDeletion(child.getFile().getPath(), prevRevision, revision, repo);
@@ -400,7 +400,7 @@ final class SvnFileHistoryGraph implements FileHistoryGraph {
      */
     private void addEdge(final ExistingFileHistoryNode ancestor, final SvnFileHistoryNode descendant,
             final boolean copyChildren) {
-        ancestor.addDescendant(descendant, new FileDiff());
+        ancestor.addDescendant(descendant, new FileDiff(descendant.getFile()));
         if (copyChildren) {
             this.copyChildNodes(ancestor, descendant);
         }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFragmentTracer.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFragmentTracer.java
@@ -30,10 +30,7 @@ public class SvnFragmentTracer implements IFragmentTracer {
                 final FileHistoryNode descendant = this.fileHistoryGraph.getNodeFor(leafRevision);
                 final FileDiff fileDiff = descendant.buildHistory(node);
                 final Fragment lastFragment = fileDiff.traceFragment(fragment);
-                result.add(ChangestructureFactory.createFragment(
-                        descendant.getFile(),
-                        lastFragment.getFrom(),
-                        lastFragment.getTo()));
+                result.add(lastFragment);
             }
         }
 

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFragmentTracer.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFragmentTracer.java
@@ -46,10 +46,7 @@ public class SvnFragmentTracer implements IFragmentTracer {
         final FileHistoryNode node = this.fileHistoryGraph.getNodeFor(file);
         if (node != null) {
             for (final FileInRevision leafRevision : this.fileHistoryGraph.getLatestFiles(file)) {
-                result.add(ChangestructureFactory.createFileInRevision(
-                        leafRevision.getPath(),
-                        ChangestructureFactory.createLocalRevision(),
-                        leafRevision.getRepository()));
+                result.add(leafRevision);
             }
         }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/Multimap.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/Multimap.java
@@ -18,6 +18,13 @@ public final class Multimap<K, V> {
     private final Map<K, List<V>> map = new LinkedHashMap<>();
 
     /**
+     * @return {@code true} iff the multimap is empty.
+     */
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    /**
      * Add the given key value pair. If there already is an entry
      * for the given key, add the value to the end of this key's list.
      */
@@ -71,6 +78,9 @@ public final class Multimap<K, V> {
         final List<V> list = this.map.get(key);
         if (list != null) {
             list.remove(value);
+            if (list.isEmpty()) {
+                this.removeKey(key);
+            }
         }
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/diffalgorithms/MyersSourceDiffAlgorithm.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/diffalgorithms/MyersSourceDiffAlgorithm.java
@@ -181,10 +181,10 @@ class MyersSourceDiffAlgorithm implements IDiffAlgorithm {
             } else {
                 final Fragment original = ChangestructureFactory.createFragment(fileOldInfo,
                         ChangestructureFactory.createPositionInText(startOld + 1, 1),
-                        ChangestructureFactory.createPositionInText(endOld + 1, 0));
+                        ChangestructureFactory.createPositionInText(endOld + 1, 1));
                 final Fragment revised = ChangestructureFactory.createFragment(fileNewInfo,
                         ChangestructureFactory.createPositionInText(startNew + 1, 1),
-                        ChangestructureFactory.createPositionInText(endNew + 1, 0));
+                        ChangestructureFactory.createPositionInText(endNew + 1, 1));
                 final Pair<Fragment, Fragment> delta = Pair.create(original, revised);
                 ret.add(delta);
             }
@@ -245,6 +245,6 @@ class MyersSourceDiffAlgorithm implements IDiffAlgorithm {
                 ChangestructureFactory.createPositionInText(
                         lineIndex + 1, prefixLength + 1),
                 ChangestructureFactory.createPositionInText(
-                        lineIndex + 1, line.length() - suffixLength));
+                        lineIndex + 1, line.length() - suffixLength + 1));
     }
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/diffalgorithms/SimpleSourceDiffAlgorithm.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/diffalgorithms/SimpleSourceDiffAlgorithm.java
@@ -196,7 +196,7 @@ class SimpleSourceDiffAlgorithm implements IDiffAlgorithm {
                 ChangestructureFactory.createPositionInText(
                         fragmentData.toIndexInWholeFile(0) + 1, prefixLength + 1),
                 ChangestructureFactory.createPositionInText(
-                        fragmentData.toIndexInWholeFile(0) + 1, line.length() - suffixLength));
+                        fragmentData.toIndexInWholeFile(0) + 1, line.length() - suffixLength + 1));
     }
 
     private Fragment toFileFragment(FileInRevision fileInfo, OneFileView<String> fragmentData) {
@@ -204,7 +204,7 @@ class SimpleSourceDiffAlgorithm implements IDiffAlgorithm {
                 ChangestructureFactory.createPositionInText(
                         fragmentData.toIndexInWholeFile(0) + 1, 1),
                 ChangestructureFactory.createPositionInText(
-                        fragmentData.toIndexInWholeFile(fragmentData.getItemCount() - 1) + 2, 0));
+                        fragmentData.toIndexInWholeFile(fragmentData.getItemCount() - 1) + 2, 1));
     }
 
     private FullFileView<String> toLines(byte[] contents, String charset) throws IOException {

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/Constants.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/Constants.java
@@ -12,4 +12,6 @@ public final class Constants {
     public static final String STOPMARKER_ID = "de.setsoftware.reviewtool.tourStopMarker";
     public static final String INACTIVESTOPMARKER_ID = "de.setsoftware.reviewtool.inactiveTourStopMarker";
 
+    public static final String INCOMING_COLOR = "INCOMING_COLOR";
+
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ChangestructureFactory.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ChangestructureFactory.java
@@ -41,8 +41,4 @@ public class ChangestructureFactory {
     public static PositionInText createPositionInText(int line, int column) {
         return new PositionInText(line, column);
     }
-
-    public static PositionInText createPositionInText(int line, int column, int absoluteOffset) {
-        return new PositionInText(line, column, absoluteOffset);
-    }
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Delta.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Delta.java
@@ -1,0 +1,107 @@
+package de.setsoftware.reviewtool.model.changestructure;
+
+/**
+ * A delta in a text file, denoted by line and column offset.
+ */
+public final class Delta {
+
+    private final int lineOffset;
+    private final int columnOffset;
+
+    /**
+     * Creates an empty delta (with line offset and column offset set to zero).
+     */
+    Delta() {
+        this(0, 0);
+    }
+
+    /**
+     * Creates a delta.
+     * @param lineOffset The line offset.
+     * @param columnOffset The column offset.
+     */
+    Delta(final int lineOffset, final int columnOffset) {
+        this.lineOffset = lineOffset;
+        this.columnOffset = columnOffset;
+    }
+
+    @Override
+    public int hashCode() {
+        return (100 * this.lineOffset + this.columnOffset) * 37;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (!(o instanceof Delta)) {
+            return false;
+        }
+        final Delta p = (Delta) o;
+        return this.lineOffset == p.lineOffset && this.columnOffset == p.columnOffset;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + this.lineOffset + "," + this.columnOffset + ")";
+    }
+
+    /**
+     * Returns the line offset.
+     */
+    public int getLineOffset() {
+        return this.lineOffset;
+    }
+
+    /**
+     * Returns the column offset.
+     */
+    public int getColumnOffset() {
+        return this.columnOffset;
+    }
+
+    /**
+     * @return {@code true} if this is an in-line delta, i.e. if the line offset is zero.
+     */
+    public boolean isInline() {
+        return this.lineOffset == 0;
+    }
+
+    /**
+     * Returns the sum of this Delta and another one.
+     * @param other The other Delta.
+     * @return The sum of this Delta and the passed one.
+     */
+    public Delta plus(final Delta other) {
+        return new Delta(this.lineOffset + other.lineOffset, this.columnOffset + other.columnOffset);
+    }
+
+    /**
+     * Returns the difference between this Delta and another one.
+     * @param other The other Delta.
+     * @return The difference between this Delta and the passed one.
+     */
+    public Delta minus(final Delta other) {
+        return new Delta(this.lineOffset - other.lineOffset, this.columnOffset - other.columnOffset);
+    }
+
+    /**
+     * @return This delta with negated line and column offsets.
+     */
+    public Delta negate() {
+        return new Delta(-this.lineOffset, -this.columnOffset);
+    }
+
+    /**
+     * @return A copy of {@code this} with the column offset set to zero.
+     */
+    public Delta ignoreColumnOffset() {
+        return this.ignoreColumnOffset(true);
+    }
+
+    /**
+     * @return If {@code ignore} is set to true, a copy of {@code this} with the column offset set to zero,
+     *      {@code this} otherwise.
+     */
+    public Delta ignoreColumnOffset(final boolean ignore) {
+        return new Delta(this.lineOffset, ignore ? 0 : this.columnOffset);
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
@@ -86,42 +86,11 @@ public final class FileDiff {
      * @return The resulting fragment matching the last known file revision.
      */
     public Fragment traceFragment(final Fragment source) {
-        final List<Hunk> hunks = new ArrayList<Hunk>();
-        for (final Hunk hunk : this.hunks) {
-            if (hunk.getSource().overlaps(source)) {
-                hunks.add(hunk);
-            } else if (source.getTo().lessThan(hunk.getSource().getFrom())) {
-                break;
-            }
-        }
         try {
-            return this.createCombinedFragment(hunks, source).setFile(this.toRevision);
+            return this.createCombinedFragment(source).setFile(this.toRevision);
         } catch (final IncompatibleFragmentException e) {
             throw new Error(e);
         }
-    }
-
-    /**
-     * Returns a list of hunks related to a collection of target fragments. "Related to" means that their target
-     * fragments either overlap a given target fragment or that their target fragments are adjacent to a given target
-     * fragment.
-     *
-     * @param fragments The target fragments to "reach".
-     * @return A list of hunks whose target fragments overlap or are adjacent to a collection of given target
-     *          fragments.
-     */
-    public List<Hunk> getHunksForTargets(final Collection<? extends Fragment> fragments) {
-        final List<Hunk> result = new ArrayList<>();
-        for (final Hunk hunk : this.hunks) {
-            final Fragment target = hunk.getTarget();
-            for (final Fragment selector : fragments) {
-                if (target.equals(selector) || target.overlaps(selector) || target.isAdjacentTo(selector)) {
-                    result.add(hunk);
-                    break;
-                }
-            }
-        }
-        return result;
     }
 
     /**
@@ -149,24 +118,29 @@ public final class FileDiff {
      * @throws IncompatibleFragmentException if the hunk to be merged overlaps with some hunk in the FileDiff object.
      */
     public FileDiff merge(final Hunk hunkToMerge) throws IncompatibleFragmentException {
-        if (this.containsInLineDiff(hunkToMerge)) {
-            return this.merge(this.makeFullLine(hunkToMerge));
-        }
         final FileDiff result = new FileDiff(this.fromRevision, hunkToMerge.getTarget().getFile());
         final List<Hunk> stashedHunks = new ArrayList<Hunk>();
+        final Delta hunkDelta = hunkToMerge.getDelta();
+        final int hunkStartLine = hunkToMerge.getSource().getFrom().getLine();
         boolean hunkCreated = false;
         for (final Hunk hunk : this.hunks) {
             if (hunk.getTarget().overlaps(hunkToMerge.getSource())) {
                 stashedHunks.add(hunk);
-            } else if (hunk.getTarget().getTo().compareTo(hunkToMerge.getSource().getFrom()) < 0) {
+            } else if (hunk.getTarget().getTo().compareTo(hunkToMerge.getSource().getFrom()) <= 0) {
                 result.hunks.add(hunk.adjustTargetFile(result.toRevision));
             } else if (hunkCreated) {
-                result.hunks.add(hunk.adjustTarget(hunkToMerge.getDelta()).adjustTargetFile(result.toRevision));
+                result.hunks.add(
+                        hunk.adjustTarget(hunkDelta.ignoreColumnOffset(
+                                hunk.getTarget().getFrom().getLine() != hunkStartLine))
+                        .adjustTargetFile(result.toRevision));
             } else {
                 result.hunks.add(this.createCombinedHunk(stashedHunks, hunkToMerge)
                         .adjustSourceFile(this.fromRevision)
                         .adjustTargetFile(result.toRevision));
-                result.hunks.add(hunk.adjustTarget(hunkToMerge.getDelta()).adjustTargetFile(result.toRevision));
+                result.hunks.add(
+                        hunk.adjustTarget(hunkDelta.ignoreColumnOffset(
+                                hunk.getTarget().getFrom().getLine() != hunkStartLine))
+                        .adjustTargetFile(result.toRevision));
                 hunkCreated = true;
             }
         }
@@ -190,14 +164,14 @@ public final class FileDiff {
      * @throws IncompatibleFragmentException if some hunk to be merged overlaps with some hunk in the FileDiff object.
      */
     public FileDiff merge(final Collection<? extends Hunk> hunksToMerge) throws IncompatibleFragmentException {
-        final List<Hunk> fullLineHunks = this.makeFullLine(hunksToMerge);
-
         FileDiff result = this;
-        int delta = 0;
-        for (Hunk hunk : fullLineHunks) {
-            hunk = hunk.adjustSource(delta);
-            result = result.merge(hunk);
-            delta += hunk.getDelta();
+        Delta delta = new Delta();
+        int lastLine = 0;
+        for (Hunk hunk : hunksToMerge) {
+            delta = delta.ignoreColumnOffset(hunk.getSource().getFrom().getLine() != lastLine);
+            result = result.merge(hunk.adjustSource(delta));
+            delta = delta.plus(hunk.getDelta());
+            lastLine = hunk.getSource().getTo().getLine();
         }
         return result;
     }
@@ -213,33 +187,6 @@ public final class FileDiff {
      */
     public FileDiff merge(final FileDiff diff) throws IncompatibleFragmentException {
         return this.merge(diff.hunks).setTo(diff.toRevision);
-    }
-
-    private boolean containsInLineDiff(Hunk hunk) {
-        return hunk.getSource().getFrom().getColumn() != 1
-            || hunk.getSource().getTo().getColumn() != 0
-            || hunk.getTarget().getFrom().getColumn() != 1
-            || hunk.getTarget().getTo().getColumn() != 0;
-    }
-
-    private List<Hunk> makeFullLine(Collection<? extends Hunk> hunks) {
-        final List<Hunk> ret = new ArrayList<>();
-        for (final Hunk hunk : hunks) {
-            if (this.containsInLineDiff(hunk)) {
-                ret.add(this.makeFullLine(hunk));
-            } else {
-                ret.add(hunk);
-            }
-        }
-        return ret;
-    }
-
-    private Hunk makeFullLine(Hunk hunk) {
-        return new Hunk(this.makeFullLine(hunk.getSource()), this.makeFullLine(hunk.getTarget()));
-    }
-
-    private Fragment makeFullLine(Fragment target) {
-        return new Fragment(target.getFile(), target.getFrom().startOfLine(), target.getTo().endOfLine(), target);
     }
 
     /**
@@ -285,28 +232,51 @@ public final class FileDiff {
      * @throws IncompatibleFragmentException if the hunk to be merged overlaps with some hunk in the hunk list
      *      or if the resulting parts cannot be combined into one fragment.
      */
-    private Fragment createCombinedFragment(final Collection<? extends Hunk> hunks,
-            final Fragment fragment)
+    private Fragment createCombinedFragment(final Fragment fragment)
             throws IncompatibleFragmentException {
 
-        final int targetDelta = this.computeDeltaViaSourceFragmentUpTo(fragment.getFrom());
-        int sourceDelta = 0;
+        final FragmentList result = new FragmentList();
+        Fragment fragmentRest = fragment;
+        Delta delta = new Delta();
+        int lastLine = 0;
 
-        FragmentList result = new FragmentList(fragment);
-        for (final Hunk hunk : hunks) {
-            final Fragment source = hunk.getSource().adjust(sourceDelta);
-            result = result.subtract(source)
-                    .move(source.getTo(), hunk.getDelta())
-                    .moveInLine(source.getTo(), hunk.getColumnDelta());
-            result.addFragment(hunk.getTarget().adjust(-targetDelta));
-            sourceDelta += hunk.getDelta();
+        for (final Hunk hunk : this.hunks) {
+            final Fragment source = hunk.getSource();
+            if (source.overlaps(fragment)) {
+                final Fragment target = hunk.getTarget();
+                result.addFragment(target);
+
+                if (fragmentRest != null) {
+                    final FragmentList pieces = fragmentRest.subtract(source);
+                    fragmentRest = null;
+                    for (final Fragment piece : pieces.getFragments()) {
+                        if (piece.getTo().compareTo(source.getFrom()) <= 0) {
+                            delta = delta.ignoreColumnOffset(piece.getFrom().getLine() != lastLine);
+                            result.addFragment(piece.adjust(delta));
+                        } else {
+                            fragmentRest = piece;
+                        }
+                    }
+                }
+            } else if (fragment.getTo().compareTo(source.getFrom()) <= 0) {
+                break;
+            }
+
+            delta = delta.ignoreColumnOffset(hunk.getSource().getFrom().getLine() != lastLine);
+            delta = delta.plus(hunk.getDelta());
+            lastLine = hunk.getSource().getTo().getLine();
+        }
+
+        if (fragmentRest != null) {
+            delta = delta.ignoreColumnOffset(fragmentRest.getFrom().getLine() != lastLine);
+            result.addFragment(fragmentRest.adjust(delta));
         }
 
         result.coalesce();
         if (result.getFragments().size() != 1) {
             throw new IncompatibleFragmentException();
         }
-        return result.getFragments().get(0).adjust(targetDelta);
+        return result.getFragments().get(0);
     }
 
     /**
@@ -325,11 +295,13 @@ public final class FileDiff {
             final FragmentList sources,
             final FragmentList targets) throws IncompatibleFragmentException {
         final FragmentList combinedSources = new FragmentList();
+        combinedSources.addFragmentList(sources);
+
         for (final Fragment fragment : hunkToMerge.getSource().subtract(targets).getFragments()) {
-            combinedSources.addFragment(fragment.adjust(-this.computeDeltaViaTargetFragmentUpTo(fragment.getFrom())));
+            combinedSources.addFragment(fragment.adjust(
+                    this.computeDeltaViaTargetFragmentUpTo(fragment.getFrom()).negate()));
         }
 
-        combinedSources.addFragmentList(sources);
         combinedSources.coalesce();
         if (combinedSources.getFragments().size() != 1) {
             throw new IncompatibleFragmentException();
@@ -349,8 +321,9 @@ public final class FileDiff {
      */
     private Fragment combineTargets(final Hunk hunkToMerge, final FragmentList targets)
             throws Error, IncompatibleFragmentException {
+
         final FragmentList adjustedTargets = new FragmentList();
-        final int hunkDelta = hunkToMerge.getDelta();
+        final Delta hunkDelta = hunkToMerge.getDelta();
         final Fragment hunkTarget = hunkToMerge.getTarget();
         final PositionInText hunkTargetStart = hunkTarget.getFrom();
         final Set<Fragment> hunkOrigins = new LinkedHashSet<>();
@@ -361,13 +334,13 @@ public final class FileDiff {
                     hunkOrigins.add(curTarget);
                     final FragmentList pieces = curTarget.subtract(hunkToMerge.getSource());
                     for (final Fragment piece : pieces.getFragments()) {
-                        if (piece.getTo().lessThan(hunkTargetStart)) {
+                        if (piece.getTo().compareTo(hunkTargetStart) <= 0) {
                             adjustedTargets.addFragment(piece);
                         } else {
                             adjustedTargets.addFragment(piece.adjust(hunkDelta));
                         }
                     }
-                } else if (curTarget.getTo().lessThan(hunkTargetStart)) {
+                } else if (curTarget.getTo().compareTo(hunkTargetStart) <= 0) {
                     adjustedTargets.addFragment(curTarget);
                 } else {
                     adjustedTargets.addFragment(curTarget.adjust(hunkDelta));
@@ -383,6 +356,7 @@ public final class FileDiff {
                 hunkTarget.getTo(),
                 hunkOrigins);
         final FragmentList combinedTargets = adjustedTargets.overlayBy(newHunkTarget);
+
         combinedTargets.coalesce();
         if (combinedTargets.getFragments().size() != 1) {
             throw new IncompatibleFragmentException();
@@ -398,36 +372,18 @@ public final class FileDiff {
      * @param pos The position in the target file.
      * @return The line delta.
      */
-    private int computeDeltaViaTargetFragmentUpTo(final PositionInText pos) {
-        int result = 0;
+    private Delta computeDeltaViaTargetFragmentUpTo(final PositionInText pos) {
+        Delta delta = new Delta();
+        int lastLine = 0;
         for (final Hunk hunk : this.hunks) {
-            if (hunk.getTarget().getTo().lessThan(pos)) {
-                result += hunk.getDelta();
-            } else if (!hunk.getTarget().getFrom().lessThan(pos)) {
+            if (hunk.getTarget().getTo().compareTo(pos) <= 0) {
+                delta = delta.ignoreColumnOffset(hunk.getTarget().getFrom().getLine() != lastLine);
+                delta = delta.plus(hunk.getDelta());
+                lastLine = hunk.getTarget().getTo().getLine();
+            } else {
                 break;
             }
         }
-        return result;
+        return delta.ignoreColumnOffset(pos.getLine() != lastLine);
     }
-
-    /**
-     * Returns the target line delta to be added given a source {@link PositionInText} because of hunks applied
-     * before this line. It is computed as the number of lines earlier hunks added minus the number of lines
-     * earlier hunks deleted.
-     *
-     * @param pos The position in the source file.
-     * @return The line delta.
-     */
-    private int computeDeltaViaSourceFragmentUpTo(final PositionInText pos) {
-        int result = 0;
-        for (final Hunk hunk : this.hunks) {
-            if (hunk.getSource().getTo().lessThan(pos)) {
-                result += hunk.getDelta();
-            } else if (!hunk.getSource().getFrom().lessThan(pos)) {
-                break;
-            }
-        }
-        return result;
-    }
-
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
@@ -20,7 +20,7 @@ public class FileDiff {
     private FileInRevision toRevision;
 
     /**
-     * Creates an empty FileDiff object.
+     * Creates an empty FileDiff object that will be filled with hunks.
      */
     public FileDiff(final FileInRevision revision) {
         this.hunks = new ArrayList<>();
@@ -31,8 +31,17 @@ public class FileDiff {
     /**
      * Creates a FileDiff object that will be filled with hunks.
      */
-    private FileDiff(final FileInRevision fromRevision, final FileInRevision toRevision) {
+    public FileDiff(final FileInRevision fromRevision, final FileInRevision toRevision) {
         this.hunks = new ArrayList<>();
+        this.fromRevision = fromRevision;
+        this.toRevision = toRevision;
+    }
+
+    /**
+     * Creates a fully specified FileDiff object.
+     */
+    private FileDiff(final FileInRevision fromRevision, final FileInRevision toRevision, final List<Hunk> hunks) {
+        this.hunks = new ArrayList<>(hunks);
         this.fromRevision = fromRevision;
         this.toRevision = toRevision;
     }
@@ -59,6 +68,16 @@ public class FileDiff {
         return this.toRevision;
     }
 
+    /**
+     * Creates a copy of this object with a new target revision. The list of hunks is copied in such a way that
+     * both lists can be modified separately after the copy.
+     *
+     * @param newTo The new target revision.
+     * @return The requested copy.
+     */
+    public FileDiff setTo(final FileInRevision newTo) {
+        return new FileDiff(this.fromRevision, newTo, this.hunks);
+    }
     /**
      * Traces a source fragment over the recorded hunks to the last known file revision.
      * @param source The source fragment.
@@ -177,7 +196,7 @@ public class FileDiff {
      * @throws IncompatibleFragmentException if some hunk to be merged overlaps with some hunk in the FileDiff object.
      */
     public FileDiff merge(final FileDiff diff) throws IncompatibleFragmentException {
-        return this.merge(diff.hunks);
+        return this.merge(diff.hunks).setTo(diff.toRevision);
     }
 
     private boolean containsInLineDiff(Hunk hunk) {

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
@@ -64,7 +64,7 @@ public class FileDiff {
      * @param source The source fragment.
      * @return The resulting fragment matching the last known file revision.
      */
-    public Fragment traceFragment(Fragment source) {
+    public Fragment traceFragment(final Fragment source) {
         final List<Hunk> hunks = new ArrayList<Hunk>();
         for (final Hunk hunk : this.hunks) {
             if (hunk.getSource().overlaps(source)) {
@@ -74,7 +74,7 @@ public class FileDiff {
             }
         }
         try {
-            return this.createCombinedFragment(hunks, source);
+            return this.createCombinedFragment(hunks, source).setFile(this.toRevision);
         } catch (final IncompatibleFragmentException e) {
             throw new Error(e);
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Fragment.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Fragment.java
@@ -221,6 +221,15 @@ public class Fragment implements Comparable<Fragment> {
         return this.to.lessThan(this.from);
     }
 
+    /**
+     * Creates a fragment whose file is set to the one passed.
+     * @param newFile The {@link FileInRevision} to use.
+     * @return The resulting fragment.
+     */
+    Fragment setFile(final FileInRevision newFile) {
+        return new Fragment(newFile, this.from, this.to);
+    }
+
     @Override
     public int hashCode() {
         return this.from.hashCode() + 31 * this.file.hashCode();

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FragmentList.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FragmentList.java
@@ -34,8 +34,15 @@ public class FragmentList {
     /**
      * @return A read-only view on the fragments in this fragment list.
      */
-    public List<Fragment> getFragments() {
+    public List<? extends Fragment> getFragments() {
         return Collections.unmodifiableList(this.fragments);
+    }
+
+    /**
+     * @return {@code true} if this fragment list is empty.
+     */
+    public boolean isEmpty() {
+        return this.fragments.isEmpty();
     }
 
     /**
@@ -97,8 +104,8 @@ public class FragmentList {
     }
 
     /**
-     * Overlays this fragment list by some {@link Fragment}. That means that parts that overlap are taken from the
-     * fragment passed.
+     * Overlays this fragment list by some {@link Fragment}. That means that parts that overlap are taken
+     * from the fragment passed.
      * @param fragment The fragment.
      * @return A fragment list storing the overlay result.
      */

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FragmentList.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FragmentList.java
@@ -57,7 +57,7 @@ public class FragmentList {
             final Fragment oldFragment = it.next();
             if (oldFragment.overlaps(fragment)) {
                 throw new IncompatibleFragmentException();
-            } else if (posTo.compareTo(oldFragment.getFrom()) < 0) {
+            } else if (posTo.compareTo(oldFragment.getFrom()) <= 0) {
                 it.previous();
                 it.add(fragment);
                 return;
@@ -121,7 +121,7 @@ public class FragmentList {
         final ListIterator<Fragment> it = this.fragments.listIterator();
         while (it.hasNext()) {
             final Fragment oldFragment = it.next();
-            if (posTo.lessThan(oldFragment.getFrom())) {
+            if (posTo.compareTo(oldFragment.getFrom()) <= 0) {
                 break;
             }
 
@@ -182,36 +182,15 @@ public class FragmentList {
     /**
      * Moves fragments starting at a given position.
      * @param pos The start position.
-     * @param offset The line offset to apply.
+     * @param delta The delta to apply.
      */
-    public FragmentList move(final PositionInText pos, final int offset) {
+    public FragmentList move(final PositionInText pos, final Delta delta) {
         final FragmentList result = new FragmentList();
         for (final Fragment fragment : this.fragments) {
-            if (fragment.getFrom().lessThan(pos)) {
+            if (fragment.getFrom().compareTo(pos) <= 0) {
                 result.fragments.add(fragment);
             } else {
-                result.fragments.add(fragment.adjust(offset));
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Moves fragments that occur in the same line as pos after pos' column
-     * @param pos The start position.
-     * @param offsetInColumns The column offset to apply.
-     */
-    public FragmentList moveInLine(final PositionInText pos, final int offsetInColumns) {
-        if (offsetInColumns == 0) {
-            return this;
-        }
-
-        final FragmentList result = new FragmentList();
-        for (final Fragment fragment : this.fragments) {
-            if (fragment.getFrom().getLine() != pos.getLine() || fragment.getFrom().lessThan(pos)) {
-                result.fragments.add(fragment);
-            } else {
-                result.fragments.add(fragment.adjustColumnIfInLine(offsetInColumns, pos.getLine()));
+                result.fragments.add(fragment.adjust(delta));
             }
         }
         return result;

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
@@ -4,8 +4,10 @@ import java.util.Collection;
 
 /**
  * Encapsulates a single difference between two revisions of a file, i.e. a pair (source fragment, target fragment).
+ * <p/>
+ * Hunks can be ordered according to their source fragment.
  */
-public class Hunk {
+public final class Hunk implements Comparable<Hunk> {
 
     /**
      * The source fragment.
@@ -77,7 +79,7 @@ public class Hunk {
     /**
      * Combines all source fragments of a collection of hunks.
      * @param hunks The collection of hunks.
-     * @return A FragmentList containing all source fragments of the hunks in order.
+     * @return A FragmentList containing all source fragments of the hunks in order. Adjacent fragments are merged.
      */
     public static FragmentList getSources(final Collection<? extends Hunk> hunks) {
         final FragmentList result = new FragmentList();
@@ -95,7 +97,7 @@ public class Hunk {
     /**
      * Combines all target fragments of a collection of hunks.
      * @param hunks The collection of hunks.
-     * @return A FragmentList containing all target fragments of the hunks in order.
+     * @return A FragmentList containing all target fragments of the hunks in order. Adjacent fragments are merged.
      */
     public static FragmentList getTargets(final Collection<? extends Hunk> hunks) {
         final FragmentList result = new FragmentList();
@@ -181,6 +183,11 @@ public class Hunk {
         } else {
             return 0;
         }
+    }
+
+    @Override
+    public int compareTo(final Hunk o) {
+        return this.source.compareTo(o.getSource());
     }
 
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
@@ -152,6 +152,24 @@ public class Hunk {
     }
 
     /**
+     * Creates a new hunk whose source fragment's file is set to the one passed.
+     * @param source The {@link FileInRevision} to use.
+     * @return The resulting hunk.
+     */
+    Hunk adjustSourceFile(final FileInRevision source) {
+        return new Hunk(this.source.setFile(source), this.target);
+    }
+
+    /**
+     * Creates a new hunk whose target fragment's file is set to the one passed.
+     * @param source The {@link FileInRevision} to use.
+     * @return The resulting hunk.
+     */
+    Hunk adjustTargetFile(final FileInRevision target) {
+        return new Hunk(this.source, this.target.setFile(target));
+    }
+
+    /**
      * Returns the negative delta of this hunk if passed position is behind this hunk. This is helpful if some given
      * position has to be adjusted by "counting away" this hunk.
      * @param pos The position in question.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/PositionInText.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/PositionInText.java
@@ -1,7 +1,7 @@
 package de.setsoftware.reviewtool.model.changestructure;
 
 /**
- * A position in a text file, denoted by line and column number.
+ * A position in a text file, denoted by character index.
  */
 public class PositionInText implements Comparable<PositionInText> {
 
@@ -11,10 +11,7 @@ public class PositionInText implements Comparable<PositionInText> {
     private final int column;
 
     PositionInText(int line, int column) {
-        this(line, column, -1);
-    }
-
-    PositionInText(final int line, final int column, final int absoluteOffset) {
+        assert column > 0 || column == 0 && line == 0;
         this.line = line;
         this.column = column;
     }
@@ -46,21 +43,6 @@ public class PositionInText implements Comparable<PositionInText> {
         return this.column;
     }
 
-    public PositionInText nextInLine() {
-        return new PositionInText(this.line, this.column + 1);
-    }
-
-    /**
-     * @return A new PositionInText object with the same line but decremented column.
-     */
-    public PositionInText prevInLine() {
-        return new PositionInText(this.line, this.column - 1);
-    }
-
-    public PositionInText toPrevLine() {
-        return new PositionInText(this.line - 1, this.column);
-    }
-
     public boolean lessThan(PositionInText other) {
         return this.compareTo(other) < 0;
     }
@@ -84,12 +66,22 @@ public class PositionInText implements Comparable<PositionInText> {
     }
 
     /**
-     * Adjusts the position giving a column offset.
-     * @param columnOffset The column offset to add to current column.
-     * @return A new PositionInText object with the same line but adjusted column.
+     * Adds a delta to this position.
+     * @param delta The delta to add to position.
+     * @return A new PositionInText object.
      */
-    public PositionInText adjustColumn(int columnOffset) {
-        return new PositionInText(this.line, this.column + columnOffset);
+    public PositionInText plus(final Delta delta) {
+        return new PositionInText(this.line + delta.getLineOffset(), this.column + delta.getColumnOffset());
+    }
+
+    /**
+     * Returns the difference between this PositionInText and another one.
+     * @param other The other PositionInText.
+     * @return The delta between this PositionInText and the passed one.
+     * @post {@code other.plus(result).equals(this)}
+     */
+    public Delta minus(final PositionInText other) {
+        return new Delta(this.line - other.line, this.column - other.column);
     }
 
     /**

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/PositionLookupTable.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/PositionLookupTable.java
@@ -82,7 +82,7 @@ public class PositionLookupTable {
             return this.charCountAtEndOfLine.get(this.charCountAtEndOfLine.size() - 1);
         }
 
-        return this.charCountAtEndOfLine.get(pos.getLine() - 1) + pos.getColumn();
+        return this.charCountAtEndOfLine.get(pos.getLine() - 1) + pos.getColumn() - 1;
     }
 
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Stop.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Stop.java
@@ -108,6 +108,13 @@ public class Stop implements IReviewElement {
     }
 
     /**
+     * Returns {@code true} if this stop represents a binary change.
+     */
+    public boolean isBinaryChange() {
+        return this.history.isEmpty();
+    }
+
+    /**
      * Return true iff this stop can be merged with the given other stop.
      * Two stops can be merged if they denote the same file and directly
      * neighboring or overlapping segments of that file (or the whole binary file).

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Stop.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Stop.java
@@ -1,9 +1,10 @@
 package de.setsoftware.reviewtool.model.changestructure;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import de.setsoftware.reviewtool.base.Multimap;
@@ -18,8 +19,8 @@ import de.setsoftware.reviewtool.base.Util;
  */
 public class Stop implements IReviewElement {
 
-    private final List<FileInRevision> historyOrder = new ArrayList<>();
-    private final Multimap<FileInRevision, Fragment> history = new Multimap<>();
+    private final Map<FileInRevision, FileInRevision> historyOrder;
+    private final Multimap<FileInRevision, Hunk> history;
 
     private final FileInRevision mostRecentFile;
     private final Fragment mostRecentFragment;
@@ -32,53 +33,49 @@ public class Stop implements IReviewElement {
      * Constructor for textual changes.
      */
     public Stop(
-            Fragment from,
-            Fragment to,
-            Fragment traceFragment,
-            boolean irrelevantForReview,
-            final boolean isVisible) {
-        this.historyOrder.add(from.getFile());
-        this.historyOrder.add(to.getFile());
-        this.history.put(from.getFile(), from);
-        this.history.put(to.getFile(), to);
+            final TextualChangeHunk change,
+            final Fragment traceFragment) {
+        this.historyOrder = new LinkedHashMap<>();
+        this.historyOrder.put(change.getFrom(), change.getTo());
+        this.history = new Multimap<>();
+        this.history.put(change.getFrom(), new Hunk(change));
 
         this.mostRecentFile = traceFragment.getFile();
         this.mostRecentFragment = traceFragment;
 
-        this.irrelevantForReview = irrelevantForReview;
-        this.isVisible = isVisible;
+        this.irrelevantForReview = change.isIrrelevantForReview();
+        this.isVisible = change.isVisible();
     }
 
     /**
      * Constructor for binary changes.
      */
     public Stop(
-            FileInRevision from,
-            FileInRevision to,
-            FileInRevision traceFile,
-            boolean irrelevantForReview,
-            final boolean isVisible) {
-        this.historyOrder.add(from);
-        this.historyOrder.add(to);
+            final BinaryChange change,
+            final FileInRevision traceFile) {
+        this.historyOrder = new LinkedHashMap<>();
+        this.historyOrder.put(change.getFrom(), change.getTo());
+        this.history = new Multimap<>();
 
         this.mostRecentFile = traceFile;
         this.mostRecentFragment = null;
 
-        this.irrelevantForReview = irrelevantForReview;
-        this.isVisible = isVisible;
+        this.irrelevantForReview = change.isIrrelevantForReview();
+        this.isVisible = change.isVisible();
     }
 
     /**
      * Constructor for internal use.
      */
-    private Stop(List<FileInRevision> historyOrder,
-            Multimap<FileInRevision, Fragment> history,
-            FileInRevision mostRecentFile,
-            Fragment mostRecentFragment,
-            boolean irrelevantForReview,
+    private Stop(
+            final Map<FileInRevision, FileInRevision> historyOrder,
+            final Multimap<FileInRevision, Hunk> history,
+            final FileInRevision mostRecentFile,
+            final Fragment mostRecentFragment,
+            final boolean irrelevantForReview,
             final boolean isVisible) {
-        this.historyOrder.addAll(historyOrder);
-        this.history.putAll(history);
+        this.historyOrder = historyOrder;
+        this.history = history;
         this.mostRecentFile = mostRecentFile;
         this.mostRecentFragment = mostRecentFragment;
         this.irrelevantForReview = irrelevantForReview;
@@ -102,15 +99,11 @@ public class Stop implements IReviewElement {
         return this.mostRecentFile;
     }
 
-    public List<FileInRevision> getHistory() {
-        return this.historyOrder;
+    public Map<FileInRevision, FileInRevision> getHistory() {
+        return Collections.unmodifiableMap(this.historyOrder);
     }
 
-    public FileInRevision getLastFileRevision() {
-        return this.historyOrder.get(this.historyOrder.size() - 1);
-    }
-
-    public List<Fragment> getContentFor(FileInRevision revision) {
+    public List<Hunk> getContentFor(final FileInRevision revision) {
         return this.history.get(revision);
     }
 
@@ -121,7 +114,7 @@ public class Stop implements IReviewElement {
      * Neighboring segments are only considered mergeable if both are either
      * irrelevant or relevant.
      */
-    public boolean canBeMergedWith(Stop other) {
+    public boolean canBeMergedWith(final Stop other) {
         if (!this.mostRecentFile.equals(other.mostRecentFile)) {
             return false;
         }
@@ -151,14 +144,13 @@ public class Stop implements IReviewElement {
      * The resulting stop has a potentially larger most recent fragment, but
      * all the detail information of both stops is still contained in the history.
      */
-    public Stop merge(Stop other) {
+    public Stop merge(final Stop other) {
         assert this.canBeMergedWith(other);
 
-        final LinkedHashSet<FileInRevision> mergedFileSet = new LinkedHashSet<>(this.historyOrder);
-        mergedFileSet.addAll(other.historyOrder);
-        final List<FileInRevision> mergedHistoryOrder = FileInRevision.sortByRevision(mergedFileSet);
+        final LinkedHashMap<FileInRevision, FileInRevision> mergedHistoryOrder = new LinkedHashMap<>(this.historyOrder);
+        mergedHistoryOrder.putAll(other.historyOrder);
 
-        final Multimap<FileInRevision, Fragment> mergedHistory = new Multimap<>();
+        final Multimap<FileInRevision, Hunk> mergedHistory = new Multimap<>();
         mergedHistory.putAll(this.history);
         mergedHistory.putAll(other.history);
         mergedHistory.sortValues();
@@ -188,7 +180,7 @@ public class Stop implements IReviewElement {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (!(o instanceof Stop)) {
             return false;
         }
@@ -209,7 +201,7 @@ public class Stop implements IReviewElement {
      */
     public int getNumberOfFragments() {
         int ret = 0;
-        for (final Entry<FileInRevision, List<Fragment>> e : this.history.entrySet()) {
+        for (final Entry<FileInRevision, List<Hunk>> e : this.history.entrySet()) {
             ret += e.getValue().size();
         }
         return ret;
@@ -230,8 +222,8 @@ public class Stop implements IReviewElement {
     public int getNumberOfRemovedLines() {
         final FileInRevision oldestFile = this.historyOrder.get(0);
         int ret = 0;
-        for (final Fragment f : this.getContentFor(oldestFile)) {
-            ret += f.getNumberOfLines();
+        for (final Hunk hunk : this.getContentFor(oldestFile)) {
+            ret += hunk.getSource().getNumberOfLines();
         }
         return ret;
     }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
@@ -316,7 +316,7 @@ public class ToursInReview {
                 final IMarker marker = markerFactory.createStopMarker(resource, tourActive);
                 marker.setAttribute(IMarker.LINE_NUMBER, pos.getFrom().getLine());
                 marker.setAttribute(IMarker.CHAR_START,
-                        lookupTables.get(resource).getCharsSinceFileStart(pos.getFrom()) - 1);
+                        lookupTables.get(resource).getCharsSinceFileStart(pos.getFrom()));
                 marker.setAttribute(IMarker.CHAR_END,
                         lookupTables.get(resource).getCharsSinceFileStart(pos.getTo()));
                 return marker;

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
@@ -269,24 +269,14 @@ public class ToursInReview {
             public void handle(TextualChangeHunk visitee) {
                 final List<Fragment> mostRecentFragments = tracer.traceFragment(visitee.getToFragment());
                 for (final Fragment fragment : mostRecentFragments) {
-                    ret.add(new Stop(
-                            visitee.getFromFragment(),
-                            visitee.getToFragment(),
-                            fragment,
-                            visitee.isIrrelevantForReview(),
-                            visitee.isVisible()));
+                    ret.add(new Stop(visitee, fragment));
                 }
             }
 
             @Override
             public void handle(BinaryChange visitee) {
                 for (final FileInRevision fileInRevision : tracer.traceFile(visitee.getFrom())) {
-                    ret.add(new Stop(
-                            visitee.getFrom(),
-                            visitee.getTo(),
-                            fileInRevision,
-                            visitee.isIrrelevantForReview(),
-                            visitee.isVisible()));
+                    ret.add(new Stop(visitee, fileInRevision));
                 }
             }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
@@ -70,13 +70,17 @@ public class CombinedDiffStopViewer extends AbstractStopViewer {
                     final Fragment targetFragment = hunk.getTarget();
 
                     final int oldStartOffset =
-                            oldContents.getStartPositionOfLine(sourceFragment.getFrom().getLine() - 1);
+                            oldContents.getStartPositionOfLine(sourceFragment.getFrom().getLine() - 1)
+                                    + (sourceFragment.getFrom().getColumn() - 1);
                     final int oldEndOffset =
-                            oldContents.getStartPositionOfLine(sourceFragment.getTo().getLine() - 1);
+                            oldContents.getStartPositionOfLine(sourceFragment.getTo().getLine() - 1)
+                                    + (sourceFragment.getTo().getColumn() - 1);
                     final int newStartOffset =
-                            newContents.getStartPositionOfLine(targetFragment.getFrom().getLine() - 1);
+                            newContents.getStartPositionOfLine(targetFragment.getFrom().getLine() - 1)
+                                    + (targetFragment.getFrom().getColumn() - 1);
                     final int newEndOffset =
-                            newContents.getStartPositionOfLine(targetFragment.getTo().getLine() - 1);
+                            newContents.getStartPositionOfLine(targetFragment.getTo().getLine() - 1)
+                                    + (targetFragment.getTo().getColumn() - 1);
 
                     oldPositions.add(new Position(oldStartOffset, oldEndOffset - oldStartOffset));
                     newPositions.add(new Position(newStartOffset, newEndOffset - newStartOffset));
@@ -94,9 +98,8 @@ public class CombinedDiffStopViewer extends AbstractStopViewer {
     private Fragment createFragmentForWholeFile(final FileInRevision revision, final LineSequence contents) {
         final int numLines = contents.getNumberOfLines();
         final Fragment fragment = ChangestructureFactory.createFragment(revision,
-                ChangestructureFactory.createPositionInText(1, 1, 0),
-                ChangestructureFactory.createPositionInText(numLines + 1, 0,
-                        contents.getStartPositionOfLine(numLines)));
+                ChangestructureFactory.createPositionInText(1, 1),
+                ChangestructureFactory.createPositionInText(numLines + 1, 1));
         return fragment;
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
@@ -42,16 +42,13 @@ public class CombinedDiffStopViewer extends AbstractStopViewer {
 
         final FileHistoryNode node = tours.getFileHistoryNode(changes.get(lastRevision));
         if (node != null) {
-            final List<Hunk> hunksFirst = stop.getContentFor(firstRevision);
-            final List<Hunk> hunksLast = stop.getContentFor(lastRevision);
-            if (hunksFirst == null || hunksLast == null) {
-                // binary change
+            if (stop.isBinaryChange()) {
                 this.createDiffViewer(view, scrollContent, firstRevision, changes.get(lastRevision),
                         null, null, null, null);
             } else {
-                // textual change
                 final FileHistoryNode ancestor = tours.getFileHistoryNode(firstRevision);
                 final FileDiff diff = node.buildHistory(ancestor);
+                final List<Hunk> hunksLast = stop.getContentFor(lastRevision);
                 final List<Hunk> hunks = diff.getHunksForTargets(Hunk.getTargets(hunksLast).getFragments());
 
                 final Fragment firstSourceFragment = Hunk.getSources(hunks).getFragments().get(0);

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/ReviewContentView.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/ReviewContentView.java
@@ -54,6 +54,7 @@ import de.setsoftware.reviewtool.model.changestructure.Fragment;
 import de.setsoftware.reviewtool.model.changestructure.IReviewElement;
 import de.setsoftware.reviewtool.model.changestructure.PositionLookupTable;
 import de.setsoftware.reviewtool.model.changestructure.Stop;
+import de.setsoftware.reviewtool.model.changestructure.TextualChangeHunk;
 import de.setsoftware.reviewtool.model.changestructure.Tour;
 import de.setsoftware.reviewtool.model.changestructure.ToursInReview;
 import de.setsoftware.reviewtool.model.changestructure.ToursInReview.IToursInReviewChangeListener;
@@ -260,7 +261,12 @@ public class ReviewContentView extends ViewPart implements ReviewModeListener, I
                     stop.getMostRecentFile(),
                     stop.getMostRecentFragment().getFrom(),
                     stop.getMostRecentFragment().getFrom());
-            jumpTarget = new Stop(fragment, fragment, fragment, false, stop.isVisible());
+            final TextualChangeHunk change = ChangestructureFactory.createTextualChangeHunk(
+                    fragment,
+                    fragment,
+                    false,
+                    stop.isVisible());
+            jumpTarget = new Stop(change, fragment);
         } else {
             jumpTarget = stop;
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/ReviewContentView.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/ReviewContentView.java
@@ -282,7 +282,7 @@ public class ReviewContentView extends ViewPart implements ReviewModeListener, I
             //for files not in the workspace, we cannot create markers, but let's at least select the text
             if (stop.isDetailedFragmentKnown() && fileStore.fetchInfo().exists()) {
                 final PositionLookupTable lookup = PositionLookupTable.create(fileStore);
-                final int posStart = lookup.getCharsSinceFileStart(stop.getMostRecentFragment().getFrom()) - 1;
+                final int posStart = lookup.getCharsSinceFileStart(stop.getMostRecentFragment().getFrom());
                 final int posEnd = lookup.getCharsSinceFileStart(stop.getMostRecentFragment().getTo());
                 setSelection(part, new TextSelection(posStart, posEnd - posStart));
             }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/viewtracking/ViewStatistics.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/viewtracking/ViewStatistics.java
@@ -104,7 +104,7 @@ public class ViewStatistics {
         if (fragment == null) {
             return stats.determineViewRatioWithoutPosition(longEnoughCount);
         } else {
-            final int toCorrection = fragment.getTo().getColumn() == 0 ? -1 : 0;
+            final int toCorrection = fragment.getTo().getColumn() == 1 ? -1 : 0;
             return stats.determineViewRatio(fragment.getFrom().getLine(),
                     fragment.getTo().getLine() + toCorrection, longEnoughCount);
         }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/diffalgorithms/SimpleTextDiffAlgorithmTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/diffalgorithms/SimpleTextDiffAlgorithmTest.java
@@ -52,13 +52,13 @@ public class SimpleTextDiffAlgorithmTest {
     private static Pair<PositionInText, PositionInText> changeIn(int startIncl, int endIncl) {
         return Pair.create(
                 ChangestructureFactory.createPositionInText(startIncl, 1),
-                ChangestructureFactory.createPositionInText(endIncl + 1, 0));
+                ChangestructureFactory.createPositionInText(endIncl + 1, 1));
     }
 
     private static Pair<PositionInText, PositionInText> inLineChange(int line, int startCharIncl, int endCharExcl) {
         return Pair.create(
                 ChangestructureFactory.createPositionInText(line, startCharIncl),
-                ChangestructureFactory.createPositionInText(line, endCharExcl - 1));
+                ChangestructureFactory.createPositionInText(line, endCharExcl));
     }
 
     private static Pair<PositionInText, PositionInText> deletionAt(int line) {

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/irrelevancestrategies/basicfilters/ImportChangeFilterTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/irrelevancestrategies/basicfilters/ImportChangeFilterTest.java
@@ -22,7 +22,7 @@ public class ImportChangeFilterTest {
         return Fragment.createWithContent(
                 ChangestructureFactory.createFileInRevision("", null, null),
                 ChangestructureFactory.createPositionInText(1, 1),
-                ChangestructureFactory.createPositionInText(2, 0),
+                ChangestructureFactory.createPositionInText(2, 1),
                 content);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/irrelevancestrategies/basicfilters/PackageDeclarationFilterTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/irrelevancestrategies/basicfilters/PackageDeclarationFilterTest.java
@@ -22,7 +22,7 @@ public class PackageDeclarationFilterTest {
         return Fragment.createWithContent(
                 ChangestructureFactory.createFileInRevision("", null, null),
                 ChangestructureFactory.createPositionInText(1, 1),
-                ChangestructureFactory.createPositionInText(2, 0),
+                ChangestructureFactory.createPositionInText(2, 1),
                 content);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/irrelevancestrategies/basicfilters/WhitespaceChangeFilterTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/irrelevancestrategies/basicfilters/WhitespaceChangeFilterTest.java
@@ -22,7 +22,7 @@ public class WhitespaceChangeFilterTest {
         return Fragment.createWithContent(
                 ChangestructureFactory.createFileInRevision("", null, null),
                 ChangestructureFactory.createPositionInText(1, 1),
-                ChangestructureFactory.createPositionInText(2, 0),
+                ChangestructureFactory.createPositionInText(2, 1),
                 content);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -83,7 +83,7 @@ public class FileDiffTest {
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
-        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 0)));
+        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 0), f1, f2));
         assertEquals(expected2, ff.getFragments());
     }
 
@@ -101,12 +101,12 @@ public class FileDiffTest {
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
-        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 0)));
+        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 0), f1, f2));
         assertEquals(expected2, ff.getFragments());
     }
 
     @Test
-    public void testAddAdjacent3() throws Exception {
+    public void testAddAdjacent3a() throws Exception {
         final FragmentList ff = new FragmentList();
 
         final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
@@ -126,12 +126,12 @@ public class FileDiffTest {
         ff.addFragment(f3);
         ff.coalesce();
         final List<Fragment> expected3 = new ArrayList<>();
-        expected3.add(new Fragment(file("a.java", 1), pos(1, 1), pos(5, 0)));
+        expected3.add(new Fragment(file("a.java", 1), pos(1, 1), pos(5, 0), f1, f2, f3));
         assertEquals(expected3, ff.getFragments());
     }
 
     @Test
-    public void testAddAdjacent4() throws Exception {
+    public void testAddAdjacent4a() throws Exception {
         final FragmentList ff = new FragmentList();
 
         final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
@@ -162,7 +162,7 @@ public class FileDiffTest {
         ff.addFragmentList(ff2);
         ff.coalesce();
         final List<Fragment> expected4 = new ArrayList<>();
-        expected4.add(new Fragment(file("a.java", 1), pos(1, 1), pos(6, 0)));
+        expected4.add(new Fragment(file("a.java", 1), pos(1, 1), pos(6, 0), f1, f2, f3, f4));
         assertEquals(expected4, ff.getFragments());
     }
 
@@ -205,19 +205,25 @@ public class FileDiffTest {
                 new Fragment(f2, pos(5, 1), pos(5, 0)),
                 new Fragment(f3, pos(5, 1), pos(6, 0))));
 
-        final Fragment actual1 = diff.traceFragment(new Fragment(f1, pos(1, 1), pos(2, 0)));
+        final Fragment source1 = new Fragment(f1, pos(1, 1), pos(2, 0));
+        final Fragment actual1 = diff.traceFragment(source1);
         assertEquals(
-                new Fragment(f3, pos(1, 1), pos(2, 0)),
+                new Fragment(f3, pos(1, 1), pos(2, 0),
+                        source1),
                 actual1);
 
-        final Fragment actual2 = diff.traceFragment(new Fragment(f1, pos(7, 1), pos(9, 0)));
+        final Fragment source2 = new Fragment(f1, pos(7, 1), pos(9, 0));
+        final Fragment actual2 = diff.traceFragment(source2);
         assertEquals(
-                new Fragment(f3, pos(8, 1), pos(10, 0)),
+                new Fragment(f3, pos(8, 1), pos(10, 0), source2),
                 actual2);
 
-        final Fragment actual3 = diff.traceFragment(new Fragment(f1, pos(2, 1), pos(7, 0)));
+        final Fragment source3 = new Fragment(f1, pos(2, 1), pos(7, 0));
+        final Fragment actual3 = diff.traceFragment(source3);
         assertEquals(
-                new Fragment(f3, pos(2, 1), pos(8, 0)),
+                new Fragment(f3, pos(2, 1), pos(8, 0),
+                        source3,
+                        new Fragment(f3, pos(5, 1), pos(6, 0))),
                 actual3);
     }
 
@@ -234,26 +240,31 @@ public class FileDiffTest {
         final Fragment actual1 = diff.traceFragment(
                 new Fragment(f1, pos(1, 1), pos(2, 0)));
         assertEquals(
-                new Fragment(f3, pos(1, 1), pos(2, 0)),
+                new Fragment(f3, pos(1, 1), pos(2, 0),
+                        new Fragment(f1, pos(1, 1), pos(2, 0))),
                 actual1);
 
         final Fragment actual2 = diff.traceFragment(
                 new Fragment(f1, pos(7, 1), pos(9, 0)));
         assertEquals(
-                new Fragment(f3, pos(7, 1), pos(9, 0)),
+                new Fragment(f3, pos(7, 1), pos(9, 0),
+                        new Fragment(f1, pos(7, 1), pos(9, 0))),
                 actual2);
 
         final Fragment actual3 = diff.traceFragment(
                 new Fragment(f1, pos(2, 1), pos(7, 0)));
         assertEquals(
-                new Fragment(f3, pos(2, 1), pos(7, 0)),
+                new Fragment(f3, pos(2, 1), pos(7, 0),
+                        new Fragment(f1, pos(2, 1), pos(7, 0)),
+                        new Fragment(f3, pos(5, 10), pos(5, 14))),
                 actual3);
 
         final Fragment actual4 = diff.traceFragment(
                 new Fragment(f1, pos(5, 9), pos(5, 11)));
         //TODO the fragment is enlarged, which is more or less OK, but not always necessary
         assertEquals(
-                new Fragment(f3, pos(5, 1), pos(6, 0)),
+                new Fragment(f3, pos(5, 1), pos(6, 0),
+                        new Fragment(f3, pos(5, 10), pos(5, 14))),
                 actual4);
     }
 
@@ -275,7 +286,10 @@ public class FileDiffTest {
         final Fragment actual1 = diff.traceFragment(
                 new Fragment(f1, pos(1, 1), pos(6, 0)));
         assertEquals(
-                new Fragment(f4, pos(1, 1), pos(6, 0)),
+                new Fragment(f4, pos(1, 1), pos(6, 0),
+                        new Fragment(f1, pos(1, 1), pos(6, 0)),
+                        new Fragment(f3, pos(5, 7), pos(5, 8)),
+                        new Fragment(f4, pos(5, 9), pos(5, 10))),
                 actual1);
     }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -201,7 +201,7 @@ public class FileDiffTest {
         final FileInRevision f2 = file("a.java", 2);
         final FileInRevision f3 = file("a.java", 3);
 
-        final FileDiff diff = new FileDiff().merge(new Hunk(
+        final FileDiff diff = new FileDiff(f1).merge(new Hunk(
                 new Fragment(f2, pos(5, 1), pos(5, 0)),
                 new Fragment(f3, pos(5, 1), pos(6, 0))));
 
@@ -228,7 +228,7 @@ public class FileDiffTest {
         final FileInRevision f2 = file("a.java", 2);
         final FileInRevision f3 = file("a.java", 3);
 
-        final FileDiff diff = new FileDiff().merge(new Hunk(
+        final FileDiff diff = new FileDiff(f1).merge(new Hunk(
                 new Fragment(f2, pos(5, 10), pos(5, 14)),
                 new Fragment(f3, pos(5, 10), pos(5, 14))));
 
@@ -265,7 +265,7 @@ public class FileDiffTest {
         final FileInRevision f3 = file("a.java", 3);
         final FileInRevision f4 = file("a.java", 4);
 
-        final FileDiff diff = new FileDiff()
+        final FileDiff diff = new FileDiff(f1)
                 .merge(new Hunk(
                     new Fragment(f2, pos(5, 7), pos(5, 6)),
                     new Fragment(f3, pos(5, 7), pos(5, 8))))

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -26,13 +26,13 @@ public class FileDiffTest {
     public void testAddNonAdjacent1() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
         final List<Fragment> expected1 = new ArrayList<>();
         expected1.add(f1);
         assertEquals(expected1, ff.getFragments());
 
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 1));
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
@@ -45,13 +45,13 @@ public class FileDiffTest {
     public void testAddNonAdjacent2() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
         final List<Fragment> expected1 = new ArrayList<>();
         expected1.add(f1);
         assertEquals(expected1, ff.getFragments());
 
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(6, 1), pos(7, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(6, 1), pos(7, 1));
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
@@ -59,7 +59,7 @@ public class FileDiffTest {
         expected2.add(f2);
         assertEquals(expected2, ff.getFragments());
 
-        final Fragment f3 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 0));
+        final Fragment f3 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 1));
         ff.addFragment(f3);
         ff.coalesce();
         final List<Fragment> expected3 = new ArrayList<>();
@@ -73,17 +73,17 @@ public class FileDiffTest {
     public void testAddAdjacent1() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
         final List<Fragment> expected1 = new ArrayList<>();
         expected1.add(f1);
         assertEquals(expected1, ff.getFragments());
 
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 1));
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
-        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 0), f1, f2));
+        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 1), f1, f2));
         assertEquals(expected2, ff.getFragments());
     }
 
@@ -91,56 +91,56 @@ public class FileDiffTest {
     public void testAddAdjacent2() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 1));
         ff.addFragment(f1);
         final List<Fragment> expected1 = new ArrayList<>();
         expected1.add(f1);
         assertEquals(expected1, ff.getFragments());
 
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
-        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 0), f1, f2));
+        expected2.add(new Fragment(file("a.java", 1), pos(1, 1), pos(4, 1), f1, f2));
         assertEquals(expected2, ff.getFragments());
     }
 
     @Test
-    public void testAddAdjacent3a() throws Exception {
+    public void testAddAdjacent3() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
         final List<Fragment> expected1 = new ArrayList<>();
         expected1.add(f1);
         assertEquals(expected1, ff.getFragments());
 
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 1));
         ff.addFragment(f2);
         final List<Fragment> expected2 = new ArrayList<>();
         expected2.add(f1);
         expected2.add(f2);
         assertEquals(expected2, ff.getFragments());
 
-        final Fragment f3 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 0));
+        final Fragment f3 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 1));
         ff.addFragment(f3);
         ff.coalesce();
         final List<Fragment> expected3 = new ArrayList<>();
-        expected3.add(new Fragment(file("a.java", 1), pos(1, 1), pos(5, 0), f1, f2, f3));
+        expected3.add(new Fragment(file("a.java", 1), pos(1, 1), pos(5, 1), f1, f2, f3));
         assertEquals(expected3, ff.getFragments());
     }
 
     @Test
-    public void testAddAdjacent4a() throws Exception {
+    public void testAddAdjacent4() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
         final List<Fragment> expected1 = new ArrayList<>();
         expected1.add(f1);
         assertEquals(expected1, ff.getFragments());
 
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(4, 1), pos(5, 1));
         ff.addFragment(f2);
         ff.coalesce();
         final List<Fragment> expected2 = new ArrayList<>();
@@ -149,9 +149,9 @@ public class FileDiffTest {
         assertEquals(expected2, ff.getFragments());
 
         final FragmentList ff2 = new FragmentList();
-        final Fragment f3 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 0));
+        final Fragment f3 = new Fragment(file("a.java", 1), pos(3, 1), pos(4, 1));
         ff2.addFragment(f3);
-        final Fragment f4 = new Fragment(file("a.java", 1), pos(5, 1), pos(6, 0));
+        final Fragment f4 = new Fragment(file("a.java", 1), pos(5, 1), pos(6, 1));
         ff2.addFragment(f4);
         ff2.coalesce();
         final List<Fragment> expected3 = new ArrayList<>();
@@ -162,7 +162,7 @@ public class FileDiffTest {
         ff.addFragmentList(ff2);
         ff.coalesce();
         final List<Fragment> expected4 = new ArrayList<>();
-        expected4.add(new Fragment(file("a.java", 1), pos(1, 1), pos(6, 0), f1, f2, f3, f4));
+        expected4.add(new Fragment(file("a.java", 1), pos(1, 1), pos(6, 1), f1, f2, f3, f4));
         assertEquals(expected4, ff.getFragments());
     }
 
@@ -170,7 +170,7 @@ public class FileDiffTest {
     public void testAddOverlapping1() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
         try {
             ff.addFragment(f1);
@@ -184,9 +184,9 @@ public class FileDiffTest {
     public void testAddOverlapping2() throws Exception {
         final FragmentList ff = new FragmentList();
 
-        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
         ff.addFragment(f1);
-        final Fragment f2 = new Fragment(file("a.java", 1), pos(2, 1), pos(4, 0));
+        final Fragment f2 = new Fragment(file("a.java", 1), pos(2, 1), pos(4, 1));
         try {
             ff.addFragment(f2);
             fail("IncompatibleFragmentException expected");
@@ -202,28 +202,28 @@ public class FileDiffTest {
         final FileInRevision f3 = file("a.java", 3);
 
         final FileDiff diff = new FileDiff(f1).merge(new Hunk(
-                new Fragment(f2, pos(5, 1), pos(5, 0)),
-                new Fragment(f3, pos(5, 1), pos(6, 0))));
+                new Fragment(f2, pos(5, 1), pos(5, 1)),
+                new Fragment(f3, pos(5, 1), pos(6, 1))));
 
-        final Fragment source1 = new Fragment(f1, pos(1, 1), pos(2, 0));
+        final Fragment source1 = new Fragment(f1, pos(1, 1), pos(2, 1));
         final Fragment actual1 = diff.traceFragment(source1);
         assertEquals(
-                new Fragment(f3, pos(1, 1), pos(2, 0),
+                new Fragment(f3, pos(1, 1), pos(2, 1),
                         source1),
                 actual1);
 
-        final Fragment source2 = new Fragment(f1, pos(7, 1), pos(9, 0));
+        final Fragment source2 = new Fragment(f1, pos(7, 1), pos(9, 1));
         final Fragment actual2 = diff.traceFragment(source2);
         assertEquals(
-                new Fragment(f3, pos(8, 1), pos(10, 0), source2),
+                new Fragment(f3, pos(8, 1), pos(10, 1), source2),
                 actual2);
 
-        final Fragment source3 = new Fragment(f1, pos(2, 1), pos(7, 0));
+        final Fragment source3 = new Fragment(f1, pos(2, 1), pos(7, 1));
         final Fragment actual3 = diff.traceFragment(source3);
         assertEquals(
-                new Fragment(f3, pos(2, 1), pos(8, 0),
+                new Fragment(f3, pos(2, 1), pos(8, 1),
                         source3,
-                        new Fragment(f3, pos(5, 1), pos(6, 0))),
+                        new Fragment(f3, pos(5, 1), pos(6, 1))),
                 actual3);
     }
 
@@ -238,24 +238,24 @@ public class FileDiffTest {
                 new Fragment(f3, pos(5, 10), pos(5, 14))));
 
         final Fragment actual1 = diff.traceFragment(
-                new Fragment(f1, pos(1, 1), pos(2, 0)));
+                new Fragment(f1, pos(1, 1), pos(2, 1)));
         assertEquals(
-                new Fragment(f3, pos(1, 1), pos(2, 0),
-                        new Fragment(f1, pos(1, 1), pos(2, 0))),
+                new Fragment(f3, pos(1, 1), pos(2, 1),
+                        new Fragment(f1, pos(1, 1), pos(2, 1))),
                 actual1);
 
         final Fragment actual2 = diff.traceFragment(
-                new Fragment(f1, pos(7, 1), pos(9, 0)));
+                new Fragment(f1, pos(7, 1), pos(9, 1)));
         assertEquals(
-                new Fragment(f3, pos(7, 1), pos(9, 0),
-                        new Fragment(f1, pos(7, 1), pos(9, 0))),
+                new Fragment(f3, pos(7, 1), pos(9, 1),
+                        new Fragment(f1, pos(7, 1), pos(9, 1))),
                 actual2);
 
         final Fragment actual3 = diff.traceFragment(
-                new Fragment(f1, pos(2, 1), pos(7, 0)));
+                new Fragment(f1, pos(2, 1), pos(7, 1)));
         assertEquals(
-                new Fragment(f3, pos(2, 1), pos(7, 0),
-                        new Fragment(f1, pos(2, 1), pos(7, 0)),
+                new Fragment(f3, pos(2, 1), pos(7, 1),
+                        new Fragment(f1, pos(2, 1), pos(7, 1)),
                         new Fragment(f3, pos(5, 10), pos(5, 14))),
                 actual3);
 
@@ -263,7 +263,8 @@ public class FileDiffTest {
                 new Fragment(f1, pos(5, 9), pos(5, 11)));
         //TODO the fragment is enlarged, which is more or less OK, but not always necessary
         assertEquals(
-                new Fragment(f3, pos(5, 1), pos(6, 0),
+                new Fragment(f3, pos(5, 9), pos(5, 14),
+                        new Fragment(f1, pos(5, 9), pos(5, 11)),
                         new Fragment(f3, pos(5, 10), pos(5, 14))),
                 actual4);
     }
@@ -277,19 +278,19 @@ public class FileDiffTest {
 
         final FileDiff diff = new FileDiff(f1)
                 .merge(new Hunk(
-                    new Fragment(f2, pos(5, 7), pos(5, 6)),
-                    new Fragment(f3, pos(5, 7), pos(5, 8))))
+                    new Fragment(f2, pos(5, 7), pos(5, 7)),
+                    new Fragment(f3, pos(5, 7), pos(5, 9))))
                 .merge(new Hunk(
-                    new Fragment(f3, pos(5, 9), pos(5, 8)),
-                    new Fragment(f4, pos(5, 9), pos(5, 10))));
+                    new Fragment(f3, pos(5, 9), pos(5, 9)),
+                    new Fragment(f4, pos(5, 9), pos(5, 11))));
 
         final Fragment actual1 = diff.traceFragment(
-                new Fragment(f1, pos(1, 1), pos(6, 0)));
+                new Fragment(f1, pos(1, 1), pos(6, 1)));
         assertEquals(
-                new Fragment(f4, pos(1, 1), pos(6, 0),
-                        new Fragment(f1, pos(1, 1), pos(6, 0)),
-                        new Fragment(f3, pos(5, 7), pos(5, 8)),
-                        new Fragment(f4, pos(5, 9), pos(5, 10))),
+                new Fragment(f4, pos(1, 1), pos(6, 1),
+                        new Fragment(f1, pos(1, 1), pos(6, 1)),
+                        new Fragment(f3, pos(5, 7), pos(5, 9)),
+                        new Fragment(f4, pos(5, 9), pos(5, 11))),
                 actual1);
     }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -206,19 +206,18 @@ public class FileDiffTest {
                 new Fragment(f3, pos(5, 1), pos(6, 0))));
 
         final Fragment actual1 = diff.traceFragment(new Fragment(f1, pos(1, 1), pos(2, 0)));
-        //TODO shouldn't the resulting fragment have file revision 3 (and not 1)? applies to other tests, too.
         assertEquals(
-                new Fragment(f1, pos(1, 1), pos(2, 0)),
+                new Fragment(f3, pos(1, 1), pos(2, 0)),
                 actual1);
 
         final Fragment actual2 = diff.traceFragment(new Fragment(f1, pos(7, 1), pos(9, 0)));
         assertEquals(
-                new Fragment(f1, pos(8, 1), pos(10, 0)),
+                new Fragment(f3, pos(8, 1), pos(10, 0)),
                 actual2);
 
         final Fragment actual3 = diff.traceFragment(new Fragment(f1, pos(2, 1), pos(7, 0)));
         assertEquals(
-                new Fragment(f1, pos(2, 1), pos(8, 0)),
+                new Fragment(f3, pos(2, 1), pos(8, 0)),
                 actual3);
     }
 
@@ -235,19 +234,19 @@ public class FileDiffTest {
         final Fragment actual1 = diff.traceFragment(
                 new Fragment(f1, pos(1, 1), pos(2, 0)));
         assertEquals(
-                new Fragment(f1, pos(1, 1), pos(2, 0)),
+                new Fragment(f3, pos(1, 1), pos(2, 0)),
                 actual1);
 
         final Fragment actual2 = diff.traceFragment(
                 new Fragment(f1, pos(7, 1), pos(9, 0)));
         assertEquals(
-                new Fragment(f1, pos(7, 1), pos(9, 0)),
+                new Fragment(f3, pos(7, 1), pos(9, 0)),
                 actual2);
 
         final Fragment actual3 = diff.traceFragment(
                 new Fragment(f1, pos(2, 1), pos(7, 0)));
         assertEquals(
-                new Fragment(f1, pos(2, 1), pos(7, 0)),
+                new Fragment(f3, pos(2, 1), pos(7, 0)),
                 actual3);
 
         final Fragment actual4 = diff.traceFragment(

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FragmentTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FragmentTest.java
@@ -150,42 +150,42 @@ public class FragmentTest {
     public void testMerge2() {
         final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
         final Fragment f2 = new Fragment(file(), pos(2, 1), pos(3, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0), f1, f2));
     }
 
     @Test
     public void testMerge3() {
         final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
         final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 5));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0), f1, f2));
     }
 
     @Test
     public void testMerge4() {
         final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
         final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 0), f1, f2));
     }
 
     @Test
     public void testMerge5() {
         final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
         final Fragment f2 = new Fragment(file(), pos(3, 1), pos(7, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 0), f1, f2));
     }
 
     @Test
     public void testMerge7() {
         final Fragment f1 = new Fragment(file(), pos(3, 1), pos(5, 0));
         final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(2, 1), pos(7, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(2, 1), pos(7, 0), f1, f2));
     }
 
     @Test
     public void testMerge8() {
         final Fragment f1 = new Fragment(file(), pos(3, 1), pos(4, 6));
         final Fragment f2 = new Fragment(file(), pos(4, 3), pos(5, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(3, 1), pos(5, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(3, 1), pos(5, 0), f1, f2));
     }
 
     @Test
@@ -199,14 +199,14 @@ public class FragmentTest {
     public void testMergeWithDeletionFragment4() {
         final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 0));
         final Fragment f2 = new Fragment(file(), pos(5, 1), pos(5, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 0), f1, f2));
     }
 
     @Test
     public void testMergeWithDeletionFragment5() {
         final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 0));
         final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 0)));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 0), f1, f2));
     }
 
     @Test

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FragmentTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FragmentTest.java
@@ -36,99 +36,99 @@ public class FragmentTest {
 
     @Test
     public void testCanBeMerged1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(3, 1));
         assertTrue(f1.canBeMergedWith(f2));
     }
 
     @Test
     public void testCanBeMerged2() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(3, 1));
         assertTrue(f1.canBeMergedWith(f2));
     }
 
     @Test
     public void testCanBeMerged3() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 5));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 6));
         assertTrue(f1.canBeMergedWith(f2));
     }
 
     @Test
     public void testCanBeMerged4() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 1));
         assertTrue(f1.canBeMergedWith(f2));
     }
 
     @Test
     public void testCanBeMerged5() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(7, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(7, 1));
         assertTrue(f1.canBeMergedWith(f2));
         assertTrue(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMerged6() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(4, 1), pos(7, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(4, 1), pos(7, 1));
         assertFalse(f1.canBeMergedWith(f2));
         assertFalse(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMerged7() {
-        final Fragment f1 = new Fragment(file(), pos(3, 1), pos(5, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 0));
+        final Fragment f1 = new Fragment(file(), pos(3, 1), pos(5, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 1));
         assertTrue(f1.canBeMergedWith(f2));
         assertTrue(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMerged8() {
-        final Fragment f1 = new Fragment(file(), pos(1, 10), pos(1, 13));
-        final Fragment f2 = new Fragment(file(), pos(1, 20), pos(1, 23));
+        final Fragment f1 = new Fragment(file(), pos(1, 10), pos(1, 14));
+        final Fragment f2 = new Fragment(file(), pos(1, 20), pos(1, 24));
         assertFalse(f1.canBeMergedWith(f2));
         assertFalse(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMergedWithDeletionFragment1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 1));
         assertTrue(f1.canBeMergedWith(f2));
     }
 
     @Test
     public void testCanBeMergedWithDeletionFragment2() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(2, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(2, 1));
         assertFalse(f1.canBeMergedWith(f2));
         assertFalse(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMergedWithDeletionFragment3() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 1));
+        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(3, 1));
         assertFalse(f1.canBeMergedWith(f2));
         assertFalse(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMergedWithDeletionFragment4() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 0));
-        final Fragment f2 = new Fragment(file(), pos(5, 1), pos(5, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 1));
+        final Fragment f2 = new Fragment(file(), pos(5, 1), pos(5, 1));
         assertTrue(f1.canBeMergedWith(f2));
         assertTrue(f2.canBeMergedWith(f1));
     }
 
     @Test
     public void testCanBeMergedWithDeletionFragment5() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 1));
         assertTrue(f1.canBeMergedWith(f2));
         assertTrue(f2.canBeMergedWith(f1));
     }
@@ -141,217 +141,217 @@ public class FragmentTest {
 
     @Test
     public void testMerge1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0)));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 1)));
     }
 
     @Test
     public void testMerge2() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(3, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(3, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 1), f1, f2));
     }
 
     @Test
     public void testMerge3() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 5));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 6));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(3, 1), f1, f2));
     }
 
     @Test
     public void testMerge4() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 1), f1, f2));
     }
 
     @Test
     public void testMerge5() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(7, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(7, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(7, 1), f1, f2));
     }
 
     @Test
     public void testMerge7() {
-        final Fragment f1 = new Fragment(file(), pos(3, 1), pos(5, 0));
-        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(2, 1), pos(7, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(3, 1), pos(5, 1));
+        final Fragment f2 = new Fragment(file(), pos(2, 1), pos(7, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(2, 1), pos(7, 1), f1, f2));
     }
 
     @Test
     public void testMerge8() {
-        final Fragment f1 = new Fragment(file(), pos(3, 1), pos(4, 6));
-        final Fragment f2 = new Fragment(file(), pos(4, 3), pos(5, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(3, 1), pos(5, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(3, 1), pos(4, 7));
+        final Fragment f2 = new Fragment(file(), pos(4, 3), pos(5, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(3, 1), pos(5, 1), f1, f2));
     }
 
     @Test
     public void testMergeWithDeletionFragment1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(1, 0)));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(1, 1)));
     }
 
     @Test
     public void testMergeWithDeletionFragment4() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 0));
-        final Fragment f2 = new Fragment(file(), pos(5, 1), pos(5, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 1));
+        final Fragment f2 = new Fragment(file(), pos(5, 1), pos(5, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 1), f1, f2));
     }
 
     @Test
     public void testMergeWithDeletionFragment5() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 0));
-        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 0), f1, f2));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(5, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(1, 1));
+        testMergeSymmetric(f1, f2, new Fragment(file(), pos(1, 1), pos(5, 1), f1, f2));
     }
 
     @Test
     public void testIsNeighboring1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(1, 1), pos(3, 1));
         assertFalse(f1.isNeighboring(f2));
     }
 
     @Test
     public void testIsNeighboring2() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(6, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(6, 1));
         assertTrue(f1.isNeighboring(f2));
     }
 
     @Test
     public void testIsNeighboring3() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(6, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(3, 1), pos(6, 1));
         assertTrue(f2.isNeighboring(f1));
     }
 
     @Test
     public void testIsNeighboring4() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(4, 1), pos(7, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(4, 1), pos(7, 1));
         assertFalse(f1.isNeighboring(f2));
     }
 
     @Test
     public void testIsNeighboring5() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
-        final Fragment f2 = new Fragment(file(), pos(4, 1), pos(7, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
+        final Fragment f2 = new Fragment(file(), pos(4, 1), pos(7, 1));
         assertFalse(f2.isNeighboring(f1));
     }
 
     @Test
     public void testIsNeighboring6() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 3));
-        final Fragment f2 = new Fragment(file(), pos(1, 4), pos(1, 6));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 4));
+        final Fragment f2 = new Fragment(file(), pos(1, 4), pos(1, 7));
         assertTrue(f2.isNeighboring(f1));
     }
 
     @Test
     public void testIsNeighboring7() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 3));
-        final Fragment f2 = new Fragment(file(), pos(1, 4), pos(1, 6));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 4));
+        final Fragment f2 = new Fragment(file(), pos(1, 4), pos(1, 7));
         assertTrue(f1.isNeighboring(f2));
     }
 
     @Test
     public void testIsNeighboring8() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 3));
-        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 5));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 4));
+        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 6));
         assertFalse(f2.isNeighboring(f1));
     }
 
     @Test
     public void testIsNeighboring9() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 3));
-        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 5));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 4));
+        final Fragment f2 = new Fragment(file(), pos(1, 3), pos(1, 6));
         assertFalse(f1.isNeighboring(f2));
     }
 
     @Test
     public void testIsNeighboring10() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 3));
-        final Fragment f2 = new Fragment(file(), pos(1, 5), pos(1, 7));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 4));
+        final Fragment f2 = new Fragment(file(), pos(1, 5), pos(1, 8));
         assertFalse(f2.isNeighboring(f1));
     }
 
     @Test
     public void testIsNeighboring11() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 3));
-        final Fragment f2 = new Fragment(file(), pos(1, 5), pos(1, 7));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 4));
+        final Fragment f2 = new Fragment(file(), pos(1, 5), pos(1, 8));
         assertFalse(f1.isNeighboring(f2));
     }
 
     @Test
     public void testGetNumberOfLines1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(2, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(2, 1));
         assertEquals(1, f1.getNumberOfLines());
     }
 
     @Test
     public void testGetNumberOfLines2() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(3, 1));
         assertEquals(2, f1.getNumberOfLines());
     }
 
     @Test
     public void testGetNumberOfLines3() {
-        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(6, 0));
+        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(6, 1));
         assertEquals(2, f1.getNumberOfLines());
     }
 
     @Test
     public void testGetNumberOfLines4() {
-        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(4, 0));
-        assertEquals(0, f1.getNumberOfLines());
-    }
-
-    @Test
-    public void testGetNumberOfLines5() {
         final Fragment f1 = new Fragment(file(), pos(4, 1), pos(4, 1));
         assertEquals(0, f1.getNumberOfLines());
     }
 
     @Test
+    public void testGetNumberOfLines5() {
+        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(4, 2));
+        assertEquals(0, f1.getNumberOfLines());
+    }
+
+    @Test
     public void testGetNumberOfLines6() {
-        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(5, 1));
+        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(5, 2));
         assertEquals(1, f1.getNumberOfLines());
     }
 
     @Test
     public void testGetNumberOfLines7() {
-        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(4, 3));
+        final Fragment f1 = new Fragment(file(), pos(4, 1), pos(4, 4));
         assertEquals(0, f1.getNumberOfLines());
     }
 
     @Test
     public void testGetContent1() {
-        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 0));
+        final Fragment f1 = new Fragment(file(), pos(1, 1), pos(1, 1));
         assertEquals("", f1.getContentFullLines());
     }
 
     @Test
     public void testGetContent2() {
         final String content = "abcdef";
-        final Fragment f1 = new Fragment(fileWithContent(content), pos(1, 2), pos(1, 3));
+        final Fragment f1 = new Fragment(fileWithContent(content), pos(1, 2), pos(1, 4));
         assertEquals("abcdef\n", f1.getContentFullLines());
     }
 
     @Test
     public void testGetContent3() {
         final String content = "a\nb\nc\nd\ne\nf\n";
-        final Fragment f1 = new Fragment(fileWithContent(content), pos(2, 1), pos(5, 0));
+        final Fragment f1 = new Fragment(fileWithContent(content), pos(2, 1), pos(5, 1));
         assertEquals("b\nc\nd\n", f1.getContentFullLines());
     }
 
     @Test
     public void testGetContent4() {
         final String content = "a\nb\nc\nd\ne\nf\n";
-        final Fragment f1 = new Fragment(fileWithContent(content), pos(2, 2), pos(5, 1));
+        final Fragment f1 = new Fragment(fileWithContent(content), pos(2, 2), pos(5, 2));
         assertEquals("b\nc\nd\ne\n", f1.getContentFullLines());
     }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
@@ -12,8 +12,8 @@ import org.junit.Test;
  */
 public class HunkMergeTest {
 
-    private static FileInRevision file() {
-        return new FileInRevision("file", new LocalRevision(), StubRepo.INSTANCE);
+    private static FileInRevision file(final int revision) {
+        return new FileInRevision("file", new RepoRevision(revision), StubRepo.INSTANCE);
     }
 
     private static PositionInText pos(int line, int col) {
@@ -22,193 +22,280 @@ public class HunkMergeTest {
 
     @Test
     public void testMergeSingleAdditionOnEmptyHunkList1() throws IncompatibleFragmentException {
-        final FileDiff list = new FileDiff();
-        final Hunk hunk = new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(1, 0)));
-        final FileDiff mergedList = list.merge(hunk);
+        final FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(1, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(hunk);
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(2), pos(1, 1), pos(1, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
-    public void testMergeSingleAdditionOnEmptyHunkList12() throws IncompatibleFragmentException {
-        final FileDiff list = new FileDiff();
-        final Hunk hunk = new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0)));
-        final FileDiff mergedList = list.merge(hunk);
+    public void testMergeSingleAdditionOnEmptyHunkList2() throws IncompatibleFragmentException {
+        final FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(hunk);
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(2), pos(1, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
-    public void testMergeSingleAdditionOnEmptyHunkList13() throws IncompatibleFragmentException {
-        final FileDiff list = new FileDiff();
-        final Hunk hunk = new Hunk(new Fragment(file(), pos(5, 1), pos(5, 0)),
-                new Fragment(file(), pos(5, 1), pos(7, 0)));
-        final FileDiff mergedList = list.merge(hunk);
+    public void testMergeSingleAdditionOnEmptyHunkList3() throws IncompatibleFragmentException {
+        final FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(5, 1), pos(5, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(5, 1), pos(7, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(hunk);
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(2), pos(5, 1), pos(7, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleAdditionOnNonEmptyHunkList1() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(2, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(2, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(3), pos(2, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleAdditionOnNonEmptyHunkList2() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(1, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(2, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev2.setFile(file(1)),
+                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(2, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleAdditionOnNonEmptyHunkList3() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(3, 1), pos(3, 0)),
-                new Fragment(file(), pos(3, 1), pos(4, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(3, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(4, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(2, 0))));
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(2, 1), pos(2, 0)),
-                new Fragment(file(), pos(3, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(2, 1), pos(2, 0)),
+                new Fragment(file(3), pos(3, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSinglePartlyOverlappingChange1() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(3, 0)),
-                new Fragment(file(), pos(2, 1), pos(4, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(3, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(4, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                sourceRev1,
+                new Fragment(file(3), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSinglePartlyOverlappingChange2() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(2, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                targetRev2));
+
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(
+                new Fragment(file(2), pos(1, 1), pos(2, 0)),
+                targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(3), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleFullyOverlappingChange() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(2, 0)),
-                new Fragment(file(), pos(2, 1), pos(5, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(6, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(2, 1), pos(2, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(2, 1), pos(5, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(6, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(3, 0)),
+                new Fragment(file(3), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeSingleMultiplyOverlappingChange1() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(4, 1), pos(4, 0)),
-                new Fragment(file(), pos(4, 1), pos(6, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(5, 0)),
-                new Fragment(file(), pos(2, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 0));
+        list = list.merge(new Hunk(sourceRev2, targetRev3));
+
+        final Fragment sourceRev3 = new Fragment(file(3), pos(2, 1), pos(5, 0));
+        final Fragment targetRev4 = new Fragment(file(4), pos(2, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev3, targetRev4));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(2, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(2, 0)),
+                new Fragment(file(4), pos(1, 1), pos(4, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
 
     @Test
     public void testMergeSingleMultiplyOverlappingChange2() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(4, 1), pos(4, 0)),
-                new Fragment(file(), pos(4, 1), pos(6, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(7, 1), pos(7, 0)),
-                new Fragment(file(), pos(7, 1), pos(9, 0))));
-        final FileDiff mergedList =
-                list.merge(new Hunk(new Fragment(file(), pos(2, 1), pos(8, 0)),
-                        new Fragment(file(), pos(2, 1), pos(5, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 0));
+        list = list.merge(new Hunk(sourceRev2, targetRev3));
+
+        final Fragment sourceRev3 = new Fragment(file(3), pos(7, 1), pos(7, 0));
+        final Fragment targetRev4 = new Fragment(file(4), pos(7, 1), pos(9, 0));
+        list = list.merge(new Hunk(sourceRev3, targetRev4));
+
+        final Fragment sourceRev4 = new Fragment(file(4), pos(2, 1), pos(8, 0));
+        final Fragment targetRev5 = new Fragment(file(5), pos(2, 1), pos(5, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev4, targetRev5));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(6, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(3, 0)),
+                new Fragment(file(5), pos(1, 1), pos(6, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeAdditionAndDeletion() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(3, 1), pos(5, 0)),
-                new Fragment(file(), pos(3, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 0));
+        list = list.merge(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                targetRev2));
+
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 0));
+        list = list.merge(new Hunk(
+                new Fragment(file(2), pos(1, 1), pos(3, 0)),
+                targetRev3));
+
+        final Fragment targetRev4 = new Fragment(file(4), pos(3, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(
+                new Fragment(file(3), pos(3, 1), pos(5, 0)),
+                targetRev4));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(1, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(4), pos(1, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 
     @Test
     public void testMergeChangeAndDeletion() throws IncompatibleFragmentException {
-        FileDiff list = new FileDiff();
-        list = list.merge(new Hunk(new Fragment(file(), pos(1, 1), pos(3, 0)),
-                new Fragment(file(), pos(1, 1), pos(4, 0))));
-        final FileDiff mergedList = list.merge(new Hunk(new Fragment(file(), pos(3, 1), pos(5, 0)),
-                new Fragment(file(), pos(3, 1), pos(3, 0))));
+        FileDiff list = new FileDiff(file(1));
+
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(3, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 0));
+        list = list.merge(new Hunk(sourceRev1, targetRev2));
+
+        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(5, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(3, 0));
+        final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
+
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(new Fragment(file(), pos(1, 1), pos(4, 0)),
-                new Fragment(file(), pos(1, 1), pos(3, 0))));
+        expectedHunks.add(new Hunk(
+                new Fragment(file(1), pos(1, 1), pos(4, 0)),
+                new Fragment(file(3), pos(1, 1), pos(3, 0))));
         assertEquals(expectedHunks, actualHunks);
     }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
@@ -30,9 +30,7 @@ public class HunkMergeTest {
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
-        expectedHunks.add(new Hunk(
-                sourceRev1,
-                new Fragment(file(2), pos(1, 1), pos(1, 0))));
+        expectedHunks.add(new Hunk(sourceRev1, targetRev2));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -48,7 +46,7 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(2), pos(1, 1), pos(3, 0))));
+                new Fragment(file(2), pos(1, 1), pos(3, 0), targetRev2)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -64,7 +62,7 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(2), pos(5, 1), pos(7, 0))));
+                new Fragment(file(2), pos(5, 1), pos(7, 0), targetRev2)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -84,10 +82,10 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+                new Fragment(file(3), pos(1, 1), pos(2, 0), targetRev2)));
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(1, 0)),
-                new Fragment(file(3), pos(2, 1), pos(3, 0))));
+                new Fragment(file(1), pos(1, 1), pos(1, 0), sourceRev2),
+                new Fragment(file(3), pos(2, 1), pos(3, 0), targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -107,10 +105,10 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev2.setFile(file(1)),
-                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+                new Fragment(file(3), pos(1, 1), pos(2, 0), targetRev3)));
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(2, 1), pos(3, 0))));
+                new Fragment(file(3), pos(2, 1), pos(3, 0), targetRev2)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -130,10 +128,10 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(1, 1), pos(2, 0))));
+                new Fragment(file(3), pos(1, 1), pos(2, 0), targetRev2)));
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(2, 1), pos(2, 0)),
-                new Fragment(file(3), pos(3, 1), pos(4, 0))));
+                new Fragment(file(1), pos(2, 1), pos(2, 0), sourceRev2),
+                new Fragment(file(3), pos(3, 1), pos(4, 0), targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -153,7 +151,7 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(1, 1), pos(4, 0))));
+                new Fragment(file(3), pos(1, 1), pos(4, 0), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -175,7 +173,7 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 new Fragment(file(1), pos(1, 1), pos(1, 0)),
-                new Fragment(file(3), pos(1, 1), pos(4, 0))));
+                new Fragment(file(3), pos(1, 1), pos(4, 0), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -194,8 +192,8 @@ public class HunkMergeTest {
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(3, 0)),
-                new Fragment(file(3), pos(1, 1), pos(4, 0))));
+                new Fragment(file(1), pos(1, 1), pos(3, 0), sourceRev1, sourceRev2),
+                new Fragment(file(3), pos(1, 1), pos(4, 0), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -218,8 +216,8 @@ public class HunkMergeTest {
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(2, 0)),
-                new Fragment(file(4), pos(1, 1), pos(4, 0))));
+                new Fragment(file(1), pos(1, 1), pos(2, 0), sourceRev1, sourceRev2, sourceRev3),
+                new Fragment(file(4), pos(1, 1), pos(4, 0), targetRev2, targetRev3, targetRev4)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -247,8 +245,8 @@ public class HunkMergeTest {
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(3, 0)),
-                new Fragment(file(5), pos(1, 1), pos(6, 0))));
+                new Fragment(file(1), pos(1, 1), pos(3, 0), sourceRev1, sourceRev2, sourceRev3, sourceRev4),
+                new Fragment(file(5), pos(1, 1), pos(6, 0), targetRev2, targetRev3, targetRev4, targetRev5)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -275,7 +273,7 @@ public class HunkMergeTest {
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 new Fragment(file(1), pos(1, 1), pos(1, 0)),
-                new Fragment(file(4), pos(1, 1), pos(3, 0))));
+                new Fragment(file(4), pos(1, 1), pos(3, 0), targetRev2, targetRev3, targetRev4)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -294,8 +292,8 @@ public class HunkMergeTest {
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(4, 0)),
-                new Fragment(file(3), pos(1, 1), pos(3, 0))));
+                new Fragment(file(1), pos(1, 1), pos(4, 0), sourceRev1, sourceRev2),
+                new Fragment(file(3), pos(1, 1), pos(3, 0), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
@@ -24,8 +24,8 @@ public class HunkMergeTest {
     public void testMergeSingleAdditionOnEmptyHunkList1() throws IncompatibleFragmentException {
         final FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(1, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(1, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
@@ -38,15 +38,15 @@ public class HunkMergeTest {
     public void testMergeSingleAdditionOnEmptyHunkList2() throws IncompatibleFragmentException {
         final FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(2), pos(1, 1), pos(3, 0), targetRev2)));
+                new Fragment(file(2), pos(1, 1), pos(3, 1), targetRev2)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -54,15 +54,15 @@ public class HunkMergeTest {
     public void testMergeSingleAdditionOnEmptyHunkList3() throws IncompatibleFragmentException {
         final FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(5, 1), pos(5, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(5, 1), pos(7, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(5, 1), pos(5, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(5, 1), pos(7, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev1, targetRev2));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(2), pos(5, 1), pos(7, 0), targetRev2)));
+                new Fragment(file(2), pos(5, 1), pos(7, 1), targetRev2)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -70,22 +70,22 @@ public class HunkMergeTest {
     public void testMergeSingleAdditionOnNonEmptyHunkList1() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(2, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(3, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(2, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(3, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(1, 1), pos(2, 0), targetRev2)));
+                new Fragment(file(3), pos(1, 1), pos(2, 1), targetRev2)));
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(1, 0), sourceRev2),
-                new Fragment(file(3), pos(2, 1), pos(3, 0), targetRev3)));
+                new Fragment(file(1), pos(1, 1), pos(1, 1), sourceRev2),
+                new Fragment(file(3), pos(2, 1), pos(3, 1), targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -93,22 +93,22 @@ public class HunkMergeTest {
     public void testMergeSingleAdditionOnNonEmptyHunkList2() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(1, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(2, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(1, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(2, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev2.setFile(file(1)),
-                new Fragment(file(3), pos(1, 1), pos(2, 0), targetRev3)));
+                new Fragment(file(3), pos(1, 1), pos(2, 1), targetRev3)));
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(2, 1), pos(3, 0), targetRev2)));
+                new Fragment(file(3), pos(2, 1), pos(3, 1), targetRev2)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -116,22 +116,22 @@ public class HunkMergeTest {
     public void testMergeSingleAdditionOnNonEmptyHunkList3() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(2, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(3, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(4, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(3, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(4, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(1, 1), pos(2, 0), targetRev2)));
+                new Fragment(file(3), pos(1, 1), pos(2, 1), targetRev2)));
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(2, 1), pos(2, 0), sourceRev2),
-                new Fragment(file(3), pos(3, 1), pos(4, 0), targetRev3)));
+                new Fragment(file(1), pos(2, 1), pos(2, 1), sourceRev2),
+                new Fragment(file(3), pos(3, 1), pos(4, 1), targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -139,19 +139,19 @@ public class HunkMergeTest {
     public void testMergeSinglePartlyOverlappingChange1() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(3, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(4, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(2, 1), pos(3, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(2, 1), pos(4, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
                 sourceRev1,
-                new Fragment(file(3), pos(1, 1), pos(4, 0), targetRev2, targetRev3)));
+                new Fragment(file(3), pos(1, 1), pos(4, 1), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -159,21 +159,21 @@ public class HunkMergeTest {
     public void testMergeSinglePartlyOverlappingChange2() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 1));
         list = list.merge(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(1), pos(1, 1), pos(1, 1)),
                 targetRev2));
 
-        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(3, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(3, 1));
         final FileDiff mergedList = list.merge(new Hunk(
-                new Fragment(file(2), pos(1, 1), pos(2, 0)),
+                new Fragment(file(2), pos(1, 1), pos(2, 1)),
                 targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(1, 0)),
-                new Fragment(file(3), pos(1, 1), pos(4, 0), targetRev2, targetRev3)));
+                new Fragment(file(1), pos(1, 1), pos(1, 1)),
+                new Fragment(file(3), pos(1, 1), pos(4, 1), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -181,19 +181,19 @@ public class HunkMergeTest {
     public void testMergeSingleFullyOverlappingChange() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(2, 1), pos(2, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(2, 1), pos(5, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(2, 1), pos(2, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(2, 1), pos(5, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(6, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(1, 1), pos(6, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(3, 0), sourceRev1, sourceRev2),
-                new Fragment(file(3), pos(1, 1), pos(4, 0), targetRev2, targetRev3)));
+                new Fragment(file(1), pos(1, 1), pos(3, 1), sourceRev1, sourceRev2),
+                new Fragment(file(3), pos(1, 1), pos(4, 1), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -201,23 +201,23 @@ public class HunkMergeTest {
     public void testMergeSingleMultiplyOverlappingChange1() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 1));
         list = list.merge(new Hunk(sourceRev2, targetRev3));
 
-        final Fragment sourceRev3 = new Fragment(file(3), pos(2, 1), pos(5, 0));
-        final Fragment targetRev4 = new Fragment(file(4), pos(2, 1), pos(3, 0));
+        final Fragment sourceRev3 = new Fragment(file(3), pos(2, 1), pos(5, 1));
+        final Fragment targetRev4 = new Fragment(file(4), pos(2, 1), pos(3, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev3, targetRev4));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(2, 0), sourceRev1, sourceRev2, sourceRev3),
-                new Fragment(file(4), pos(1, 1), pos(4, 0), targetRev2, targetRev3, targetRev4)));
+                new Fragment(file(1), pos(1, 1), pos(2, 1), sourceRev1, sourceRev2, sourceRev3),
+                new Fragment(file(4), pos(1, 1), pos(4, 1), targetRev2, targetRev3, targetRev4)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -226,27 +226,27 @@ public class HunkMergeTest {
     public void testMergeSingleMultiplyOverlappingChange2() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(1, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(3, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(4, 1), pos(4, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(4, 1), pos(6, 1));
         list = list.merge(new Hunk(sourceRev2, targetRev3));
 
-        final Fragment sourceRev3 = new Fragment(file(3), pos(7, 1), pos(7, 0));
-        final Fragment targetRev4 = new Fragment(file(4), pos(7, 1), pos(9, 0));
+        final Fragment sourceRev3 = new Fragment(file(3), pos(7, 1), pos(7, 1));
+        final Fragment targetRev4 = new Fragment(file(4), pos(7, 1), pos(9, 1));
         list = list.merge(new Hunk(sourceRev3, targetRev4));
 
-        final Fragment sourceRev4 = new Fragment(file(4), pos(2, 1), pos(8, 0));
-        final Fragment targetRev5 = new Fragment(file(5), pos(2, 1), pos(5, 0));
+        final Fragment sourceRev4 = new Fragment(file(4), pos(2, 1), pos(8, 1));
+        final Fragment targetRev5 = new Fragment(file(5), pos(2, 1), pos(5, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev4, targetRev5));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(3, 0), sourceRev1, sourceRev2, sourceRev3, sourceRev4),
-                new Fragment(file(5), pos(1, 1), pos(6, 0), targetRev2, targetRev3, targetRev4, targetRev5)));
+                new Fragment(file(1), pos(1, 1), pos(3, 1), sourceRev1, sourceRev2, sourceRev3, sourceRev4),
+                new Fragment(file(5), pos(1, 1), pos(6, 1), targetRev2, targetRev3, targetRev4, targetRev5)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -254,26 +254,26 @@ public class HunkMergeTest {
     public void testMergeAdditionAndDeletion() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 0));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 1));
         list = list.merge(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(1, 0)),
+                new Fragment(file(1), pos(1, 1), pos(1, 1)),
                 targetRev2));
 
-        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 0));
+        final Fragment targetRev3 = new Fragment(file(3), pos(1, 1), pos(4, 1));
         list = list.merge(new Hunk(
-                new Fragment(file(2), pos(1, 1), pos(3, 0)),
+                new Fragment(file(2), pos(1, 1), pos(3, 1)),
                 targetRev3));
 
-        final Fragment targetRev4 = new Fragment(file(4), pos(3, 1), pos(3, 0));
+        final Fragment targetRev4 = new Fragment(file(4), pos(3, 1), pos(3, 1));
         final FileDiff mergedList = list.merge(new Hunk(
-                new Fragment(file(3), pos(3, 1), pos(5, 0)),
+                new Fragment(file(3), pos(3, 1), pos(5, 1)),
                 targetRev4));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(1, 0)),
-                new Fragment(file(4), pos(1, 1), pos(3, 0), targetRev2, targetRev3, targetRev4)));
+                new Fragment(file(1), pos(1, 1), pos(1, 1)),
+                new Fragment(file(4), pos(1, 1), pos(3, 1), targetRev2, targetRev3, targetRev4)));
         assertEquals(expectedHunks, actualHunks);
     }
 
@@ -281,19 +281,19 @@ public class HunkMergeTest {
     public void testMergeChangeAndDeletion() throws IncompatibleFragmentException {
         FileDiff list = new FileDiff(file(1));
 
-        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(3, 0));
-        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 0));
+        final Fragment sourceRev1 = new Fragment(file(1), pos(1, 1), pos(3, 1));
+        final Fragment targetRev2 = new Fragment(file(2), pos(1, 1), pos(4, 1));
         list = list.merge(new Hunk(sourceRev1, targetRev2));
 
-        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(5, 0));
-        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(3, 0));
+        final Fragment sourceRev2 = new Fragment(file(2), pos(3, 1), pos(5, 1));
+        final Fragment targetRev3 = new Fragment(file(3), pos(3, 1), pos(3, 1));
         final FileDiff mergedList = list.merge(new Hunk(sourceRev2, targetRev3));
 
         final List<Hunk> actualHunks = mergedList.getHunks();
         final List<Hunk> expectedHunks = new ArrayList<>();
         expectedHunks.add(new Hunk(
-                new Fragment(file(1), pos(1, 1), pos(4, 0), sourceRev1, sourceRev2),
-                new Fragment(file(3), pos(1, 1), pos(3, 0), targetRev2, targetRev3)));
+                new Fragment(file(1), pos(1, 1), pos(4, 1), sourceRev1, sourceRev2),
+                new Fragment(file(3), pos(1, 1), pos(3, 1), targetRev2, targetRev3)));
         assertEquals(expectedHunks, actualHunks);
     }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkTest.java
@@ -19,42 +19,42 @@ public class HunkTest {
 
     @Test
     public void testGetNumberOfColumns1() {
-        final Fragment src = new Fragment(file(), pos(1, 10), pos(1, 11));
-        final Fragment tgt = new Fragment(file(), pos(1, 10), pos(1, 11));
+        final Fragment src = new Fragment(file(), pos(1, 10), pos(1, 12));
+        final Fragment tgt = new Fragment(file(), pos(1, 10), pos(1, 12));
         final Hunk hunk = new Hunk(src, tgt);
-        assertEquals(0, hunk.getColumnDelta());
+        assertEquals(0, hunk.getDelta().getColumnOffset());
     }
 
     @Test
     public void testGetNumberOfColumns2() {
-        final Fragment src = new Fragment(file(), pos(1, 10), pos(1, 9));
-        final Fragment tgt = new Fragment(file(), pos(1, 10), pos(1, 11));
+        final Fragment src = new Fragment(file(), pos(1, 10), pos(1, 10));
+        final Fragment tgt = new Fragment(file(), pos(1, 10), pos(1, 12));
         final Hunk hunk = new Hunk(src, tgt);
-        assertEquals(2, hunk.getColumnDelta());
+        assertEquals(2, hunk.getDelta().getColumnOffset());
     }
 
     @Test
     public void testGetNumberOfColumns3() {
-        final Fragment src = new Fragment(file(), pos(1, 10), pos(1, 11));
-        final Fragment tgt = new Fragment(file(), pos(1, 10), pos(1, 9));
+        final Fragment src = new Fragment(file(), pos(1, 10), pos(1, 12));
+        final Fragment tgt = new Fragment(file(), pos(1, 10), pos(1, 10));
         final Hunk hunk = new Hunk(src, tgt);
-        assertEquals(-2, hunk.getColumnDelta());
+        assertEquals(-2, hunk.getDelta().getColumnOffset());
     }
 
     @Test
     public void testGetNumberOfColumns4() {
-        final Fragment src = new Fragment(file(), pos(1, 8), pos(1, 8));
-        final Fragment tgt = new Fragment(file(), pos(1, 12), pos(1, 16));
+        final Fragment src = new Fragment(file(), pos(1, 8), pos(1, 9));
+        final Fragment tgt = new Fragment(file(), pos(1, 12), pos(1, 17));
         final Hunk hunk = new Hunk(src, tgt);
-        assertEquals(4, hunk.getColumnDelta());
+        assertEquals(4, hunk.getDelta().getColumnOffset());
     }
 
     @Test
     public void testGetNumberOfColumns5() {
-        final Fragment src = new Fragment(file(), pos(1, 8), pos(1, 8));
-        final Fragment tgt = new Fragment(file(), pos(1, 8), pos(2, 0));
+        final Fragment src = new Fragment(file(), pos(1, 8), pos(1, 9));
+        final Fragment tgt = new Fragment(file(), pos(1, 8), pos(2, 1));
         final Hunk hunk = new Hunk(src, tgt);
-        assertEquals(0, hunk.getColumnDelta());
+        assertEquals(-8, hunk.getDelta().getColumnOffset());
     }
 
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PositionLookupTableTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PositionLookupTableTest.java
@@ -23,11 +23,11 @@ public class PositionLookupTableTest {
                         + "zeile laenger\r\n"
                         + "letzte zeile"));
 
-        assertEquals(1, t.getCharsSinceFileStart(pos(1, 1)));
-        assertEquals(3, t.getCharsSinceFileStart(pos(1, 3)));
-        assertEquals(10, t.getCharsSinceFileStart(pos(2, 1)));
-        assertEquals(19, t.getCharsSinceFileStart(pos(3, 1)));
-        assertEquals(34, t.getCharsSinceFileStart(pos(4, 1)));
+        assertEquals(0, t.getCharsSinceFileStart(pos(1, 1)));
+        assertEquals(2, t.getCharsSinceFileStart(pos(1, 3)));
+        assertEquals(9, t.getCharsSinceFileStart(pos(2, 1)));
+        assertEquals(18, t.getCharsSinceFileStart(pos(3, 1)));
+        assertEquals(33, t.getCharsSinceFileStart(pos(4, 1)));
     }
 
     @Test

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/StopTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/StopTest.java
@@ -2,7 +2,8 @@ package de.setsoftware.reviewtool.model.changestructure;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -17,14 +18,19 @@ public class StopTest {
 
     @Test
     public void testRevisionsInHistoryAreSortedAfterMerge() {
-        final Stop s1 = new Stop(file("a.java", 1), file("a.java", 3), file("a.java", 4), false, true);
-        final Stop s2 = new Stop(file("a.java", 2), file("a.java", 4), file("a.java", 4), false, true);
+        final Stop s1 = new Stop(
+                ChangestructureFactory.createBinaryChange(file("a.java", 1), file("a.java", 3), false, true),
+                file("a.java", 4));
+        final Stop s2 = new Stop(
+                ChangestructureFactory.createBinaryChange(file("a.java", 2), file("a.java", 4), false, true),
+                file("a.java", 4));
         final Stop merged = s1.merge(s2);
         final Stop merged2 = s2.merge(s1);
 
-        assertEquals(
-                Arrays.asList(file("a.java", 1), file("a.java", 2), file("a.java", 3), file("a.java", 4)),
-                merged.getHistory());
+        final Map<FileInRevision, FileInRevision> expected = new LinkedHashMap<>();
+        expected.put(file("a.java", 1), file("a.java", 3));
+        expected.put(file("a.java", 2), file("a.java", 4));
+        assertEquals(expected, merged.getHistory());
         assertEquals(merged, merged2);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TourTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TourTest.java
@@ -37,12 +37,12 @@ public class TourTest {
         final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
         final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
         final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s1 = new Stop(from1, to1, current1, false, true);
+        final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
         final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 0));
         final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
         final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s2 = new Stop(from2, to2, current2, false, true);
+        final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
         final Tour t1 = new Tour("tA", Collections.singletonList(s1));
         final Tour t2 = new Tour("tB", Collections.singletonList(s2));
@@ -57,17 +57,17 @@ public class TourTest {
         final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
         final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
         final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s1 = new Stop(from1, to1, current1, false, true);
+        final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
         final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 0));
         final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
         final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s2 = new Stop(from2, to2, current2, false, true);
+        final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
         final Fragment from3 = new Fragment(file("a.java", 2), pos(4, 1), pos(5, 0));
         final Fragment to3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
         final Fragment current3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
-        final Stop s3 = new Stop(from3, to3, current3, false, true);
+        final Stop s3 = new Stop(new TextualChangeHunk(from3, to3, false, true), current3);
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
         final Tour t2 = new Tour("tourB", Arrays.asList(s2, s3));
@@ -82,17 +82,17 @@ public class TourTest {
         final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
         final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
         final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s1 = new Stop(from1, to1, current1, false, true);
+        final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
         final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 0));
         final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
         final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s2 = new Stop(from2, to2, current2, false, true);
+        final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
         final Fragment from3 = new Fragment(file("a.java", 2), pos(4, 1), pos(5, 0));
         final Fragment to3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
         final Fragment current3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
-        final Stop s3 = new Stop(from3, to3, current3, false, true);
+        final Stop s3 = new Stop(new TextualChangeHunk(from3, to3, false, true), current3);
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
         final Tour t2 = new Tour("tourB", Arrays.asList(s2, s3));
@@ -107,12 +107,12 @@ public class TourTest {
         final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
         final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
         final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s1 = new Stop(from1, to1, current1, false, true);
+        final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
         final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(3, 0));
         final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
         final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
-        final Stop s2 = new Stop(from2, to2, current2, false, true);
+        final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
         final Tour t2 = new Tour("tourB", Collections.singletonList(s2));
@@ -126,8 +126,10 @@ public class TourTest {
 
     @Test
     public void testMergeOfBinaryChanges() {
-        final Stop s1 = new Stop(file("a.java", 1), file("a.java", 2), file("a.java", 3), false, true);
-        final Stop s2 = new Stop(file("a.java", 2), file("a.java", 3), file("a.java", 3), false, true);
+        final Stop s1 = new Stop(new BinaryChange(file("a.java", 1), file("a.java", 2), false, true),
+                file("a.java", 3));
+        final Stop s2 = new Stop(new BinaryChange(file("a.java", 2), file("a.java", 3), false, true),
+                file("a.java", 3));
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
         final Tour t2 = new Tour("tourB", Collections.singletonList(s2));
@@ -144,12 +146,12 @@ public class TourTest {
         final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
         final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
         final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
-        final Stop s1 = new Stop(from1, to1, current1, false, true);
+        final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
         final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(3, 0));
         final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
         final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
-        final Stop s2 = new Stop(from2, to2, current2, true, true);
+        final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, true, true), current2);
 
         assertFalse(s1.canBeMergedWith(s2));
         assertFalse(s2.canBeMergedWith(s1));
@@ -160,12 +162,12 @@ public class TourTest {
         final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
         final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(3, 0));
         final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(3, 0));
-        final Stop s1 = new Stop(from1, to1, current1, false, true);
+        final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
         final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(4, 0));
         final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(4, 0));
         final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(4, 0));
-        final Stop s2 = new Stop(from2, to2, current2, true, true);
+        final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, true, true), current2);
 
         assertTrue(s1.canBeMergedWith(s2));
         assertTrue(s2.canBeMergedWith(s1));

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TourTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TourTest.java
@@ -34,14 +34,14 @@ public class TourTest {
 
     @Test
     public void testMergeWithDifferentFiles() {
-        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
-        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 1));
+        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 1));
         final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
-        final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
-        final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 1));
+        final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 1));
         final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
         final Tour t1 = new Tour("tA", Collections.singletonList(s1));
@@ -54,19 +54,19 @@ public class TourTest {
 
     @Test
     public void testMergeWithDifferentPartsOfSameFileAndDifferentFile() {
-        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
-        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 1));
+        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 1));
         final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
-        final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
-        final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 1));
+        final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 1));
         final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
-        final Fragment from3 = new Fragment(file("a.java", 2), pos(4, 1), pos(5, 0));
-        final Fragment to3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
-        final Fragment current3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
+        final Fragment from3 = new Fragment(file("a.java", 2), pos(4, 1), pos(5, 1));
+        final Fragment to3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 1));
+        final Fragment current3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 1));
         final Stop s3 = new Stop(new TextualChangeHunk(from3, to3, false, true), current3);
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
@@ -79,19 +79,19 @@ public class TourTest {
 
     @Test
     public void testMergeOrderInFileByLine() {
-        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
-        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 1));
+        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 1));
         final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
-        final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
-        final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from2 = new Fragment(file("b.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment to2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 1));
+        final Fragment current2 = new Fragment(file("b.java", 3), pos(1, 1), pos(2, 1));
         final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
-        final Fragment from3 = new Fragment(file("a.java", 2), pos(4, 1), pos(5, 0));
-        final Fragment to3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
-        final Fragment current3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 0));
+        final Fragment from3 = new Fragment(file("a.java", 2), pos(4, 1), pos(5, 1));
+        final Fragment to3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 1));
+        final Fragment current3 = new Fragment(file("a.java", 3), pos(4, 1), pos(5, 1));
         final Stop s3 = new Stop(new TextualChangeHunk(from3, to3, false, true), current3);
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
@@ -104,14 +104,14 @@ public class TourTest {
 
     @Test
     public void testMergeOfAdjacentLines() {
-        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
-        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 1));
+        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 1));
         final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
-        final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(3, 0));
-        final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
-        final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
+        final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(3, 1));
+        final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 1));
+        final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 1));
         final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, false, true), current2);
 
         final Tour t1 = new Tour("tourA", Collections.singletonList(s1));
@@ -143,14 +143,14 @@ public class TourTest {
 
     @Test
     public void testCannotMergeNeighboringStopsWithDifferentRelevance() {
-        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 0));
-        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 0));
-        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 0));
+        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(2, 1));
+        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(2, 1));
+        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(2, 1));
         final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
-        final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(3, 0));
-        final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
-        final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 0));
+        final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(3, 1));
+        final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 1));
+        final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(3, 1));
         final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, true, true), current2);
 
         assertFalse(s1.canBeMergedWith(s2));
@@ -159,14 +159,14 @@ public class TourTest {
 
     @Test
     public void testCanMergeOverlappingStopsWithDifferentRelevance() {
-        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 0));
-        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(3, 0));
-        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(3, 0));
+        final Fragment from1 = new Fragment(file("a.java", 1), pos(1, 1), pos(3, 1));
+        final Fragment to1 = new Fragment(file("a.java", 2), pos(1, 1), pos(3, 1));
+        final Fragment current1 = new Fragment(file("a.java", 3), pos(1, 1), pos(3, 1));
         final Stop s1 = new Stop(new TextualChangeHunk(from1, to1, false, true), current1);
 
-        final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(4, 0));
-        final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(4, 0));
-        final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(4, 0));
+        final Fragment from2 = new Fragment(file("a.java", 2), pos(2, 1), pos(4, 1));
+        final Fragment to2 = new Fragment(file("a.java", 3), pos(2, 1), pos(4, 1));
+        final Fragment current2 = new Fragment(file("a.java", 3), pos(2, 1), pos(4, 1));
         final Stop s2 = new Stop(new TextualChangeHunk(from2, to2, true, true), current2);
 
         assertTrue(s1.canBeMergedWith(s2));

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/tourrestructuring/onestop/OneStopPerPartOfFileRestructuringTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/tourrestructuring/onestop/OneStopPerPartOfFileRestructuringTest.java
@@ -51,11 +51,9 @@ public class OneStopPerPartOfFileRestructuringTest {
 
     private static Stop stop(final String file, int revision) {
         return new Stop(
-                fileInRevision(file, revision - 1),
-                fileInRevision(file, revision),
-                fileInRevision(file, 100),
-                false,
-                true);
+                ChangestructureFactory.createBinaryChange(
+                        fileInRevision(file, revision - 1), fileInRevision(file, revision), false, true),
+                fileInRevision(file, 100));
     }
 
     private static Stop stop(final String file, int... revisions) {
@@ -70,11 +68,12 @@ public class OneStopPerPartOfFileRestructuringTest {
         final PositionInText posFrom = ChangestructureFactory.createPositionInText(lineFrom, 1);
         final PositionInText posTo = ChangestructureFactory.createPositionInText(lineTo + 1, 0);
         return new Stop(
-                ChangestructureFactory.createFragment(fileInRevision(file, revision - 1), posFrom, posTo),
-                ChangestructureFactory.createFragment(fileInRevision(file, revision), posFrom, posTo),
-                ChangestructureFactory.createFragment(fileInRevision(file, 100), posFrom, posTo),
-                false,
-                true);
+                ChangestructureFactory.createTextualChangeHunk(
+                        ChangestructureFactory.createFragment(fileInRevision(file, revision - 1), posFrom, posTo),
+                        ChangestructureFactory.createFragment(fileInRevision(file, revision), posFrom, posTo),
+                        false,
+                        true),
+                ChangestructureFactory.createFragment(fileInRevision(file, 100), posFrom, posTo));
     }
 
     private static Tour tour(String description, int revision, String... filesWithStops) {

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/tourrestructuring/onestop/OneStopPerPartOfFileRestructuringTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/tourrestructuring/onestop/OneStopPerPartOfFileRestructuringTest.java
@@ -66,7 +66,7 @@ public class OneStopPerPartOfFileRestructuringTest {
 
     private static Stop stopWithLines(final String file, int revision, int lineFrom, int lineTo) {
         final PositionInText posFrom = ChangestructureFactory.createPositionInText(lineFrom, 1);
-        final PositionInText posTo = ChangestructureFactory.createPositionInText(lineTo + 1, 0);
+        final PositionInText posTo = ChangestructureFactory.createPositionInText(lineTo + 1, 1);
         return new Stop(
                 ChangestructureFactory.createTextualChangeHunk(
                         ChangestructureFactory.createFragment(fileInRevision(file, revision - 1), posFrom, posTo),

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/viewtracking/ViewStatisticsTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/viewtracking/ViewStatisticsTest.java
@@ -43,7 +43,7 @@ public class ViewStatisticsTest {
     private static Stop stop(String string) {
         final FileInRevision file = ChangestructureFactory.createFileInRevision(
                 string, ChangestructureFactory.createLocalRevision(), new StubRepo());
-        return new Stop(file, file, file, false, true);
+        return new Stop(ChangestructureFactory.createBinaryChange(file, file, false, true), file);
     }
 
     private static void doTest(


### PR DESCRIPTION
(1) Incomplete FileDiffs for merged Stops
Until now, CombinedDiffStopViewer failed in two ways to compute and
present the combined FileDiff to the user given a merged Stop. The
first problem was that the set of relevant hunks computed could be too
small because hunks that were not applied to a Stop's last revision were
ignored. The second problem was that even if multiple relevant hunks
could have been determined, there was no way to present them to the
user because marking was done using selections, and an editor pane
cannot possess more than one active selected text region. This
changeset overcomes both problems.

(2) Inline diffs
Since in-line diffs were introduced, the FileDiff algorithms have not
worked correctly in all cases. The reason for this is that the original
algorithms were designed for complete-line diffs and that the
implemented workaround of making in-line diffs full lines was not
accurate in some situations, e.g. when the contents of a line were
deleted but the whole line in itself remained. This changeset adapted
the FileDiff algorithms to be able to deal with in-line diffs. The new
class Delta encapsulates a position difference consisting of a line
and a column offset.