### PR TITLE
core: model: fix revision returned by getSmallestOfComparableRevisions()

### DIFF
--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Repository.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Repository.java
@@ -47,11 +47,11 @@ public abstract class Repository {
     protected final Revision getSmallestOfComparableRevisions(Collection<? extends Revision> revisions) {
         Revision smallestSoFar = null;
         for (final Revision r : revisions) {
-            if (smallestSoFar == null) {
-                smallestSoFar = r;
-            } else if (r instanceof UnknownRevision) {
+            if (r instanceof UnknownRevision) {
                 //unknown revision (the source of an added file) is always smallest
                 return r;
+            } else if (smallestSoFar == null) {
+                smallestSoFar = r;
             } else if (r instanceof RepoRevision) {
                 if (smallestSoFar instanceof RepoRevision) {
                     final Object vs = ((RepoRevision) smallestSoFar).getId();


### PR DESCRIPTION
When the first of multiple revisions is an UnknownRevision, the
getSmallestOfComparableRevisions() method did not always return the
correct result. With this change, if an UnknownRevision is part of the
revisions to be compared, it is always returned as the smallest
revision.