### PR TITLE
Fix tracing of local changes

### DIFF
--- a/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraphTest.java
@@ -78,10 +78,10 @@ public class SvnFileHistoryGraphTest {
         final SvnFileHistoryGraph g = new SvnFileHistoryGraph();
         assertEquals(
                 Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("bcd", 42)),
-                g.getLatestFiles(file("bcd", 42)));
+                g.getLatestFiles(file("bcd", 42), false));
     }
 
     @Test
@@ -91,16 +91,16 @@ public class SvnFileHistoryGraphTest {
         g.addCopy("a", "b", rev(5), rev(6));
         assertEquals(
                 Arrays.asList(file("a", 5), file("b", 6)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("a", 5), file("b", 6)),
-                g.getLatestFiles(file("a", 5)));
+                g.getLatestFiles(file("a", 5), false));
         assertEquals(
                 Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6)));
+                g.getLatestFiles(file("a", 6), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6)));
+                g.getLatestFiles(file("b", 6), false));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class SvnFileHistoryGraphTest {
         g.addDeletion("a", rev(12));
         assertEquals(
                 Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class SvnFileHistoryGraphTest {
         g.addDeletion("a", rev(12));
         assertEquals(
                 Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
     }
 
     @Test
@@ -130,13 +130,13 @@ public class SvnFileHistoryGraphTest {
         g.addDeletion("a", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 5)));
+                g.getLatestFiles(file("a", 5), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6)));
+                g.getLatestFiles(file("b", 6), false));
     }
 
     @Test
@@ -147,13 +147,13 @@ public class SvnFileHistoryGraphTest {
         g.addCopy("a", "b", rev(5), rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 5)));
+                g.getLatestFiles(file("a", 5), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6)));
+                g.getLatestFiles(file("b", 6), false));
     }
 
     @Test
@@ -166,19 +166,19 @@ public class SvnFileHistoryGraphTest {
         g.addCopy("a", "d", rev(5), rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6), file("c", 6), file("d", 6)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("b", 6), file("c", 6), file("d", 6)),
-                g.getLatestFiles(file("a", 5)));
+                g.getLatestFiles(file("a", 5), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6)));
+                g.getLatestFiles(file("b", 6), false));
         assertEquals(
                 Arrays.asList(file("c", 6)),
-                g.getLatestFiles(file("c", 6)));
+                g.getLatestFiles(file("c", 6), false));
         assertEquals(
                 Arrays.asList(file("d", 6)),
-                g.getLatestFiles(file("d", 6)));
+                g.getLatestFiles(file("d", 6), false));
     }
 
     @Test
@@ -194,13 +194,13 @@ public class SvnFileHistoryGraphTest {
 
         assertEquals(
                 Arrays.asList(file("d", 31)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("d", 31)),
-                g.getLatestFiles(file("a", 10)));
+                g.getLatestFiles(file("a", 10), false));
         assertEquals(
                 Arrays.asList(file("a", 11)),
-                g.getLatestFiles(file("a", 11)));
+                g.getLatestFiles(file("a", 11), false));
     }
 
     @Test
@@ -213,10 +213,10 @@ public class SvnFileHistoryGraphTest {
 
         assertEquals(
                 Arrays.asList(file("b", 11)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("b", 11)),
-                g.getLatestFiles(file("a", 10)));
+                g.getLatestFiles(file("a", 10), false));
     }
 
     @Test
@@ -228,10 +228,10 @@ public class SvnFileHistoryGraphTest {
 
         assertEquals(
                 Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("a", 10)), // (a,10)-->(a,11) is not known as the graph starts at revision 11
-                g.getLatestFiles(file("a", 10)));
+                g.getLatestFiles(file("a", 10), false));
     }
 
     @Test
@@ -243,16 +243,16 @@ public class SvnFileHistoryGraphTest {
         g.addCopy("a", "b", rev(5), rev(23));
         assertEquals(
                 Arrays.asList(file("b", 23)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6)));
+                g.getLatestFiles(file("a", 6), false));
         assertEquals(
                 Arrays.asList(file("b", 23)),
-                g.getLatestFiles(file("b", 23)));
+                g.getLatestFiles(file("b", 23), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6))); //b@6 is non-existing
+                g.getLatestFiles(file("b", 6), false)); //b@6 is non-existing
     }
 
     @Test
@@ -262,19 +262,19 @@ public class SvnFileHistoryGraphTest {
         g.addCopy("a", "b", rev(5), rev(23));
         assertEquals(
                 Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("a", 5), file("b", 23)),
-                g.getLatestFiles(file("a", 5)));
+                g.getLatestFiles(file("a", 5), false));
         assertEquals(
                 Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6)));
+                g.getLatestFiles(file("a", 6), false));
         assertEquals(
                 Arrays.asList(file("b", 23)),
-                g.getLatestFiles(file("b", 23)));
+                g.getLatestFiles(file("b", 23), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6))); //b@6 is non-existing
+                g.getLatestFiles(file("b", 6), false)); //b@6 is non-existing
     }
 
     @Test
@@ -287,16 +287,16 @@ public class SvnFileHistoryGraphTest {
         g.addCopy("b", "c", rev(23), rev(24));
         assertEquals(
                 Arrays.asList(file("b", 23), file("c", 24)),
-                g.getLatestFiles(file("a", 1)));
+                g.getLatestFiles(file("a", 1), false));
         assertEquals(
                 Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6)));
+                g.getLatestFiles(file("a", 6), false));
         assertEquals(
                 Arrays.asList(file("b", 23), file("c", 24)),
-                g.getLatestFiles(file("b", 23)));
+                g.getLatestFiles(file("b", 23), false));
         assertEquals(
                 Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6))); //b@6 is non-existing
+                g.getLatestFiles(file("b", 6), false)); //b@6 is non-existing
     }
 
     @Test
@@ -312,12 +312,12 @@ public class SvnFileHistoryGraphTest {
 
         assertEquals(
                 Arrays.asList(file("a/x", 11)),
-                g.getLatestFiles(file("a/x", 11)));
+                g.getLatestFiles(file("a/x", 11), false));
         assertEquals(
                 Arrays.asList(file("a/x", 13)),
-                g.getLatestFiles(file("a/x", 13))); // a/x@13 does not exist
+                g.getLatestFiles(file("a/x", 13), false)); // a/x@13 does not exist
         assertEquals(
                 Arrays.asList(file("a/x", 11), file("b/x", 11)),
-                g.getLatestFiles(file("a/x", 2)));
+                g.getLatestFiles(file("a/x", 2), false));
     }
 }

--- a/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraphTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.api.IRepository;
@@ -33,18 +34,18 @@ public class SvnFileHistoryGraphTest {
         }
 
         @Override
-        public IRepoRevision toRevision(final String revisionId) {
-            return ChangestructureFactory.createRepoRevision(revisionId, this);
+        public IRepoRevision<ComparableWrapper<Long>> toRevision(final String revisionId) {
+            return ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(Long.parseLong(revisionId)), this);
         }
 
         @Override
-        public IRevision getSmallestRevision(Collection<? extends IRevision> revisions) {
+        public IRevision getSmallestRevision(final Collection<? extends IRevision> revisions) {
             final List<IRevision> list = new ArrayList<>(revisions);
             Collections.sort(list, new Comparator<IRevision>() {
                 @Override
-                public int compare(IRevision o1, IRevision o2) {
-                    final Long rev1 = (Long) ((IRepoRevision) o1).getId();
-                    final Long rev2 = (Long) ((IRepoRevision) o2).getId();
+                public int compare(final IRevision o1, final IRevision o2) {
+                    final Long rev1 = ComparableWrapper.<Long> unwrap(((IRepoRevision<?>) o1).getId());
+                    final Long rev2 = ComparableWrapper.<Long> unwrap(((IRepoRevision<?>) o2).getId());
                     return Long.compare(rev1, rev2);
                 }
             });
@@ -52,7 +53,7 @@ public class SvnFileHistoryGraphTest {
         }
 
         @Override
-        public byte[] getFileContents(String path, IRepoRevision revision) {
+        public byte[] getFileContents(final String path, final IRepoRevision<?> revision) {
             return new byte[0];
         }
 
@@ -62,14 +63,14 @@ public class SvnFileHistoryGraphTest {
         }
     };
 
-    private static IRevisionedFile file(String path, long revision) {
+    private static IRevisionedFile file(final String path, final long revision) {
         return ChangestructureFactory.createFileInRevision(
                 path,
                 rev(revision));
     }
 
-    private static IRepoRevision rev(long revision) {
-        return ChangestructureFactory.createRepoRevision(revision, STUB_REPO);
+    private static IRepoRevision<ComparableWrapper<Long>> rev(final long revision) {
+        return ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), STUB_REPO);
     }
 
     @Test

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/CachedLogEntryPath.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/CachedLogEntryPath.java
@@ -38,7 +38,7 @@ final class CachedLogEntryPath implements Serializable {
         if (status.getRevision().equals(SVNRevision.UNDEFINED)) {
             this.prevRevision = SVNRevision.BASE.getNumber();
         } else {
-            this.prevRevision = status.getCommittedRevision().getNumber();
+            this.prevRevision = status.getRevision().getNumber();
         }
 
         final String copySourceUrl = status.getCopyFromURL();

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnChangeSource.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnChangeSource.java
@@ -278,9 +278,10 @@ final class SvnChangeSource implements IChangeSource {
                     },
                     null); /* no change lists */
 
-            wc.clearLocalFileHistoryGraph();
             final SvnWorkingCopyRevision wcRevision = new SvnWorkingCopyRevision(wc, paths);
-            wc.getLocalFileHistoryGraph().processRevision(wcRevision);
+            final SvnFileHistoryGraph localFileHistoryGraph = new SvnFileHistoryGraph();
+            localFileHistoryGraph.processRevision(wcRevision);
+            wc.setLocalFileHistoryGraph(localFileHistoryGraph);
             revisions.add(wcRevision);
         }
 
@@ -303,9 +304,10 @@ final class SvnChangeSource implements IChangeSource {
 
         for (final Map.Entry<SvnWorkingCopy, SortedMap<String, CachedLogEntryPath>> entry : changeMap.entrySet()) {
             final SvnWorkingCopy wc = entry.getKey();
-            wc.clearLocalFileHistoryGraph();
             final SvnWorkingCopyRevision wcRevision = new SvnWorkingCopyRevision(wc, entry.getValue());
-            wc.getLocalFileHistoryGraph().processRevision(wcRevision);
+            final SvnFileHistoryGraph localFileHistoryGraph = new SvnFileHistoryGraph();
+            localFileHistoryGraph.processRevision(wcRevision);
+            wc.setLocalFileHistoryGraph(localFileHistoryGraph);
             revisions.add(wcRevision);
         }
 

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnFileHistoryGraph.java
@@ -4,11 +4,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.diffalgorithms.DiffAlgorithmFactory;
 import de.setsoftware.reviewtool.model.api.IFileHistoryNode;
 import de.setsoftware.reviewtool.model.api.ILocalRevision;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
-import de.setsoftware.reviewtool.model.api.IRevision;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitor;
 import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 import de.setsoftware.reviewtool.model.api.IUnknownRevision;
@@ -65,8 +65,8 @@ final class SvnFileHistoryGraph extends FileHistoryGraph {
             }
 
             @Override
-            public Long handleRepoRevision(final IRepoRevision revision) {
-                return (Long) revision.getId();
+            public Long handleRepoRevision(final IRepoRevision<?> revision) {
+                return ComparableWrapper.<Long> unwrap(revision.getId());
             }
 
             @Override
@@ -96,7 +96,8 @@ final class SvnFileHistoryGraph extends FileHistoryGraph {
                             path,
                             revision.toRevision(),
                             copyPath,
-                            ChangestructureFactory.createRepoRevision(pathInfo.getCopyRevision(),
+                            ChangestructureFactory.createRepoRevision(
+                                    ComparableWrapper.wrap(pathInfo.getCopyRevision()),
                                     revision.getRepository()));
                 } else {
                     this.addReplacement(path, revision.toRevision());
@@ -107,7 +108,7 @@ final class SvnFileHistoryGraph extends FileHistoryGraph {
                             copyPath,
                             path,
                             ChangestructureFactory.createRepoRevision(
-                                    pathInfo.getCopyRevision(),
+                                    ComparableWrapper.wrap(pathInfo.getCopyRevision()),
                                     revision.getRepository()),
                             revision.toRevision());
                 } else {
@@ -117,8 +118,8 @@ final class SvnFileHistoryGraph extends FileHistoryGraph {
                 this.addChange(
                         path,
                         revision.toRevision(),
-                        Collections.<IRevision>singleton(ChangestructureFactory.createRepoRevision(
-                                e.getValue().getAncestorRevision(),
+                        Collections.singleton(ChangestructureFactory.createRepoRevision(
+                                ComparableWrapper.wrap(e.getValue().getAncestorRevision()),
                                 revision.getRepository())));
             }
         }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnRepo.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnRepo.java
@@ -18,6 +18,7 @@ import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNURL;
 import org.tmatesoft.svn.core.io.SVNRepository;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.api.IRevision;
 import de.setsoftware.reviewtool.model.changestructure.AbstractRepository;
@@ -108,19 +109,19 @@ final class SvnRepo extends AbstractRepository {
     }
 
     @Override
-    public byte[] getFileContents(final String path, final IRepoRevision revision) throws SVNException {
-        return this.fileCache.getFileContents(path, (Long) revision.getId());
+    public byte[] getFileContents(final String path, final IRepoRevision<?> revision) throws SVNException {
+        return this.fileCache.getFileContents(path, ComparableWrapper.<Long> unwrap(revision.getId()));
     }
 
     @Override
-    public IRevision getSmallestRevision(Collection<? extends IRevision> revisions) {
+    public IRevision getSmallestRevision(final Collection<? extends IRevision> revisions) {
         return getSmallestOfComparableRevisions(revisions);
     }
 
     @Override
-    public IRepoRevision toRevision(final String revisionId) {
+    public IRepoRevision<ComparableWrapper<Long>> toRevision(final String revisionId) {
         try {
-            return ChangestructureFactory.createRepoRevision(Long.valueOf(revisionId), this);
+            return ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(Long.valueOf(revisionId)), this);
         } catch (final NumberFormatException e) {
             return null;
         }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnRepoRevision.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnRepoRevision.java
@@ -3,6 +3,7 @@ package de.setsoftware.reviewtool.changesources.svn;
 import java.util.Date;
 import java.util.Map;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.changestructure.ChangestructureFactory;
 
@@ -40,8 +41,10 @@ final class SvnRepoRevision extends AbstractSvnRevision {
     }
 
     @Override
-    public IRepoRevision toRevision() {
-        return ChangestructureFactory.createRepoRevision(this.getRevisionNumber(), this.repository);
+    public IRepoRevision<ComparableWrapper<Long>> toRevision() {
+        return ChangestructureFactory.createRepoRevision(
+                ComparableWrapper.wrap(this.getRevisionNumber()),
+                this.repository);
     }
 
     @Override

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnWorkingCopy.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnWorkingCopy.java
@@ -14,7 +14,7 @@ final class SvnWorkingCopy extends AbstractWorkingCopy {
     private final File workingCopyRoot;
     private final String relPath;
     private SvnFileHistoryGraph localFileHistoryGraph;
-    private VirtualFileHistoryGraph combinedFileHistoryGraph;
+    private final VirtualFileHistoryGraph combinedFileHistoryGraph;
 
     SvnWorkingCopy(final SvnRepo repo, final File workingCopyRoot, final String relPath) {
         this.repo = repo;
@@ -42,7 +42,7 @@ final class SvnWorkingCopy extends AbstractWorkingCopy {
     }
 
     @Override
-    public String toAbsolutePathInWc(String absolutePathInRepo) {
+    public String toAbsolutePathInWc(final String absolutePathInRepo) {
         if (absolutePathInRepo.equals(this.relPath)) {
             return this.workingCopyRoot.toString();
         } else if (absolutePathInRepo.startsWith(this.relPath + "/")) {
@@ -76,9 +76,7 @@ final class SvnWorkingCopy extends AbstractWorkingCopy {
      * Replaces the {@link SvnFileHistoryGraph} by an empty file history graph.
      */
     void clearLocalFileHistoryGraph() {
-        assert this.combinedFileHistoryGraph.size() > 0;
-        this.combinedFileHistoryGraph.remove(this.combinedFileHistoryGraph.size() - 1);
         this.localFileHistoryGraph = new SvnFileHistoryGraph();
-        this.combinedFileHistoryGraph.add(this.localFileHistoryGraph);
+        this.combinedFileHistoryGraph.setLocalFileHistoryGraph(this.localFileHistoryGraph);
     }
 }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnWorkingCopy.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnWorkingCopy.java
@@ -13,17 +13,13 @@ final class SvnWorkingCopy extends AbstractWorkingCopy {
     private final SvnRepo repo;
     private final File workingCopyRoot;
     private final String relPath;
-    private SvnFileHistoryGraph localFileHistoryGraph;
     private final VirtualFileHistoryGraph combinedFileHistoryGraph;
 
     SvnWorkingCopy(final SvnRepo repo, final File workingCopyRoot, final String relPath) {
         this.repo = repo;
         this.workingCopyRoot = workingCopyRoot;
         this.relPath = relPath;
-        this.localFileHistoryGraph = new SvnFileHistoryGraph();
-        this.combinedFileHistoryGraph = new VirtualFileHistoryGraph(
-                repo.getFileHistoryGraph(),
-                this.localFileHistoryGraph);
+        this.combinedFileHistoryGraph = new VirtualFileHistoryGraph(repo.getFileHistoryGraph());
     }
 
     @Override
@@ -66,17 +62,11 @@ final class SvnWorkingCopy extends AbstractWorkingCopy {
     }
 
     /**
-     * Returns the local file history graph.
+     * Replaces the {@link SvnFileHistoryGraph} by the passed file history graph.
+     * Note that it is not possible to change the file history graph afterwards, as the combined file history graph
+     * would not recompute the connecting edges.
      */
-    SvnFileHistoryGraph getLocalFileHistoryGraph() {
-        return this.localFileHistoryGraph;
-    }
-
-    /**
-     * Replaces the {@link SvnFileHistoryGraph} by an empty file history graph.
-     */
-    void clearLocalFileHistoryGraph() {
-        this.localFileHistoryGraph = new SvnFileHistoryGraph();
-        this.combinedFileHistoryGraph.setLocalFileHistoryGraph(this.localFileHistoryGraph);
+    void setLocalFileHistoryGraph(final SvnFileHistoryGraph localFileHistoryGraph) {
+        this.combinedFileHistoryGraph.setLocalFileHistoryGraph(localFileHistoryGraph);
     }
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/ComparableWrapper.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/ComparableWrapper.java
@@ -1,0 +1,69 @@
+package de.setsoftware.reviewtool.base;
+
+import java.io.Serializable;
+
+/**
+ * Wraps a {@link Comparable} in an object that supports the {@link IPartiallyComparable} interface.
+ *
+ * @param <T> The type of the underlying {@link Comparable}.
+ */
+public final class ComparableWrapper<T extends Comparable<T>>
+        implements IPartiallyComparable<ComparableWrapper<T>>, Serializable {
+
+    private static final long serialVersionUID = -167944665788166042L;
+    private final T wrappedComparable;
+
+    private ComparableWrapper(final T wrappedComparable) {
+        this.wrappedComparable = wrappedComparable;
+    }
+
+    /**
+     * Returns the wrapped {@link Comparable}.
+     */
+    public T getWrappedComparable() {
+        return this.wrappedComparable;
+    }
+
+    /**
+     * Wraps a {@link Comparable}.
+     * @param o The {@link Comparable} to be wrapped.
+     */
+    public static <T extends Comparable<T>> ComparableWrapper<T> wrap(final T o) {
+        return new ComparableWrapper<>(o);
+    }
+
+    /**
+     * Unwraps a {@link IPartiallyComparable} provided it is a {@link ComparableWrapper}.
+     * @param o The {@link ComparableWrapper} to be unwrapped.
+     * @throws ClassCastException if {@code o} is not a {@link ComparableWrapper}.
+     */
+    public static <T extends Comparable<T>> T unwrap(final IPartiallyComparable<?> o) {
+        @SuppressWarnings("unchecked")
+        final ComparableWrapper<T> comparable = (ComparableWrapper<T>) (o);
+        return comparable.wrappedComparable;
+    }
+
+    @Override
+    public boolean le(final ComparableWrapper<T> other) {
+        return this.wrappedComparable.compareTo(other.wrappedComparable) <= 0;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof ComparableWrapper) {
+            final ComparableWrapper<?> other = (ComparableWrapper<?>) (obj);
+            return this.wrappedComparable.equals(other.wrappedComparable);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.wrappedComparable.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.wrappedComparable.toString();
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/IPartiallyComparable.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/IPartiallyComparable.java
@@ -1,0 +1,22 @@
+package de.setsoftware.reviewtool.base;
+
+/**
+ * Represents objects that can be partially ordered.
+ *
+ * <p>The partial order is defined solely by the operation {@link #le(IPartiallyComparable)}:
+ * <ul>
+ * <li>{@code a.le(b) && b.le(a)} => {@code a} and {@code b} are equal</li>
+ * <li>{@code a.le(b) && !b.le(a)} => {@code a} comes before {@code b}</li>
+ * <li>{@code !a.le(b) && b.le(a)} => {@code b} comes before {@code a}</li>
+ * <li>{@code !a.le(b) && !b.le(a)} => {@code a} and {@code b} are incomparable</li>
+ * </ul>
+ *
+ * @param <T> The concrete type of the objects.
+ */
+public interface IPartiallyComparable<T> {
+
+    /**
+     * Returns {@code true} iff this object is less than or equal to the passed one.
+     */
+    public abstract boolean le(final T other);
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithms.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithms.java
@@ -1,0 +1,51 @@
+package de.setsoftware.reviewtool.base;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Implements some useful algorithms on partially ordered sets.
+ */
+public final class PartialOrderAlgorithms {
+
+    /**
+     * Returns some minimal element of a partially ordered set.
+     * If the underlying revisions are not totally ordered, it is unspecified which minimal element will be returned.
+     * If the collection of revisions passed is empty, {@code null} is returned.
+     * @param elements The collection of elements where to find some minimal element.
+     */
+    public static <T extends IPartiallyComparable<T>> T getSomeMinimum(final Collection<? extends T> elements) {
+        T smallestSoFar = null;
+        for (final T e : elements) {
+            if (smallestSoFar == null) {
+                smallestSoFar = e;
+            } else if (e.le(smallestSoFar) && !smallestSoFar.le(e)) {
+                smallestSoFar = e;
+            }
+        }
+        return smallestSoFar;
+    }
+
+    /**
+     * Performs a topological sort on a partially ordered collection.
+     * @param toSort The collection to be sorted topologically.
+     * @return The sorted set, represented as a list.
+     */
+    public static <T extends IPartiallyComparable<T>> List<T> topoSort(final Collection<? extends T> toSort) {
+        if (toSort.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final LinkedHashSet<T> remainingRevisions = new LinkedHashSet<>(toSort);
+        final List<T> ret = new ArrayList<>();
+        while (!remainingRevisions.isEmpty()) {
+            final T minimum = getSomeMinimum(remainingRevisions);
+            ret.add(minimum);
+            remainingRevisions.remove(minimum);
+        }
+        return ret;
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
@@ -26,6 +26,12 @@ public interface IFileHistoryGraph {
     public abstract IFileHistoryNode getNodeFor(IRevisionedFile file);
 
     /**
+     * Returns the nearest ancestor for passed {@link IRevisionedFile} having the same path, or <code>null</code>
+     * if no suitable node exists. To be suitable, the ancestor node must not be deleted.
+     */
+    public abstract IFileHistoryNode findAncestorFor(IRevisionedFile file);
+
+    /**
      * Returns the latest known versions of the given file. If all versions were deleted, the last known versions
      * before deletion are returned. If the file is unknown, a list with the file itself is
      * returned.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
@@ -1,6 +1,7 @@
 package de.setsoftware.reviewtool.model.api;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  *  A graph of files. Tracks renames, copies and deletion, so that the history of a file forms a tree.
@@ -31,7 +32,12 @@ public interface IFileHistoryGraph {
      * <p/>
      * The revisions returned are topologically sorted according to their dependencies.
      */
-    public abstract List<? extends IRevisionedFile> getLatestFiles(IRevisionedFile file);
+    public abstract List<IRevisionedFile> getLatestFiles(IRevisionedFile file);
+
+    /**
+     * Returns all non-{@link IFileHistoryNode.Type#ADDED added} nodes that do not have any ancestors but an alpha node.
+     */
+    public abstract Set<IFileHistoryNode> getIncompleteFlowStarts();
 
     /**
      * Returns the algorithm used for computing differences between file revisions.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
@@ -37,8 +37,11 @@ public interface IFileHistoryGraph {
      * returned.
      * <p/>
      * The revisions returned are topologically sorted according to their dependencies.
+     *
+     * @param file The {@link IRevisionedFile} to start with.
+     * @param ignoreNonLocalCopies If {@code true}, non-local copies are ignored.
      */
-    public abstract List<IRevisionedFile> getLatestFiles(IRevisionedFile file);
+    public abstract List<IRevisionedFile> getLatestFiles(IRevisionedFile file, boolean ignoreNonLocalCopies);
 
     /**
      * Returns all non-{@link IFileHistoryNode.Type#ADDED added} nodes that do not have any ancestors but an alpha node.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFragmentTracer.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFragmentTracer.java
@@ -14,8 +14,12 @@ public interface IFragmentTracer {
      *
      * @param fileHistoryGraph The file history graph to use for tracing.
      * @param fragment The source fragment to start with.
+     * @param ignoreNonLocalCopies If {@code true}, non-local copies are ignored while tracing.
      */
-    public abstract List<? extends IFragment> traceFragment(IFileHistoryGraph fileHistoryGraph, IFragment fragment);
+    public abstract List<? extends IFragment> traceFragment(
+            IFileHistoryGraph fileHistoryGraph,
+            IFragment fragment,
+            boolean ignoreNonLocalCopies);
 
     /**
      * Determines the target file that most closely represents the given source file in the most recent revision.
@@ -23,7 +27,10 @@ public interface IFragmentTracer {
      *
      * @param fileHistoryGraph The file history graph to use for tracing.
      * @param file The source file to start with.
+     * @param ignoreNonLocalCopies If {@code true}, non-local copies are ignored while tracing.
      */
-    public abstract List<IRevisionedFile> traceFile(IFileHistoryGraph fileHistoryGraph, IRevisionedFile file);
-
+    public abstract List<IRevisionedFile> traceFile(
+            IFileHistoryGraph fileHistoryGraph,
+            IRevisionedFile file,
+            boolean ignoreNonLocalCopies);
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRepoRevision.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRepoRevision.java
@@ -1,13 +1,16 @@
 package de.setsoftware.reviewtool.model.api;
 
+import de.setsoftware.reviewtool.base.IPartiallyComparable;
+
 /**
  * A real revision in the SCM repository.
+ *
+ * @param <RevIdT> The type of the underlying revision identifier.
  */
-public interface IRepoRevision extends IRevision {
+public interface IRepoRevision<RevIdT extends IPartiallyComparable<RevIdT>> extends IRevision {
 
     /**
      * Returns the ID of the repository revision.
      */
-    public abstract Object getId();
-
+    public abstract RevIdT getId();
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRepository.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRepository.java
@@ -16,7 +16,7 @@ public interface IRepository extends Serializable {
     /**
      * Converts the string representation of a repository revision into a {@link IRepoRevision}.
      */
-    public abstract IRepoRevision toRevision(String revisionId);
+    public abstract IRepoRevision<?> toRevision(String revisionId);
 
     /**
      * Returns one of the smallest revisions from the given collection. When there are multiple,
@@ -31,7 +31,7 @@ public interface IRepository extends Serializable {
      * @return The file contents as a byte array.
      * @throws Exception if an error occurs.
      */
-    public abstract byte[] getFileContents(String path, IRepoRevision revision) throws Exception;
+    public abstract byte[] getFileContents(String path, IRepoRevision<?> revision) throws Exception;
 
     /**
      * Returns the associated file history graph.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevision.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevision.java
@@ -2,10 +2,12 @@ package de.setsoftware.reviewtool.model.api;
 
 import java.io.Serializable;
 
+import de.setsoftware.reviewtool.base.IPartiallyComparable;
+
 /**
  * A revision of a file (or a larger unit) in a source code management system.
  */
-public interface IRevision extends Serializable {
+public interface IRevision extends IPartiallyComparable<IRevision>, Serializable {
 
     /**
      * Returns the repository this revision is associated with.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevisionVisitor.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevisionVisitor.java
@@ -19,7 +19,7 @@ public interface IRevisionVisitor<R> {
      * @param revision The revision to handle.
      * @return Some result.
      */
-    public abstract R handleRepoRevision(IRepoRevision revision);
+    public abstract R handleRepoRevision(IRepoRevision<?> revision);
 
     /**
      * Handles an {@link IUnknownRevision}.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevisionVisitorE.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevisionVisitorE.java
@@ -20,7 +20,7 @@ public interface IRevisionVisitorE<R, E extends Throwable> {
      * @param revision The revision to handle.
      * @return Some result.
      */
-    public abstract R handleRepoRevision(IRepoRevision revision) throws E;
+    public abstract R handleRepoRevision(IRepoRevision<?> revision) throws E;
 
     /**
      * Handles an {@link IUnknownRevision}.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevisionedFile.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IRevisionedFile.java
@@ -6,10 +6,12 @@ import java.io.Serializable;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 
+import de.setsoftware.reviewtool.base.IPartiallyComparable;
+
 /**
  * Denotes a certain revision of a file.
  */
-public interface IRevisionedFile extends Serializable {
+public interface IRevisionedFile extends IPartiallyComparable<IRevisionedFile>, Serializable {
 
     /**
      * Returns the path of the file (relative to the SCM repository root).

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/AbstractFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/AbstractFileHistoryGraph.java
@@ -46,7 +46,7 @@ public abstract class AbstractFileHistoryGraph implements IFileHistoryGraph {
         final IFileHistoryNode node = this.getNodeFor(file);
         if (node == null) {
             // unknown file
-            return Collections.<IFileHistoryNode> emptySet();
+            return Collections.emptySet();
         } else {
             // either node for file or descendant node shares history with passed file, follow it
             return this.getLatestFilesHelper(node, returnDeletions);
@@ -84,7 +84,7 @@ public abstract class AbstractFileHistoryGraph implements IFileHistoryGraph {
                 return result;
             }
         } else {
-            return Collections.<IFileHistoryNode> emptySet();
+            return Collections.emptySet();
         }
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/AbstractFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/AbstractFileHistoryGraph.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import de.setsoftware.reviewtool.base.PartialOrderAlgorithms;
 import de.setsoftware.reviewtool.model.api.IFileHistoryEdge;
 import de.setsoftware.reviewtool.model.api.IFileHistoryGraph;
 import de.setsoftware.reviewtool.model.api.IFileHistoryNode;
@@ -18,7 +19,7 @@ import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 public abstract class AbstractFileHistoryGraph implements IFileHistoryGraph {
 
     @Override
-    public final List<? extends IRevisionedFile> getLatestFiles(final IRevisionedFile file) {
+    public final List<IRevisionedFile> getLatestFiles(final IRevisionedFile file) {
         Set<IFileHistoryNode> nodes = this.getLatestFilesHelper(file, false);
         if (nodes.isEmpty()) {
             nodes = this.getLatestFilesHelper(file, true);
@@ -31,7 +32,7 @@ public abstract class AbstractFileHistoryGraph implements IFileHistoryGraph {
             for (final IFileHistoryNode node : nodes) {
                 revs.add(node.getFile());
             }
-            return FileInRevision.sortByRevision(revs);
+            return PartialOrderAlgorithms.topoSort(revs);
         }
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ChangeData.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ChangeData.java
@@ -3,6 +3,7 @@ package de.setsoftware.reviewtool.model.changestructure;
 import java.io.File;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,7 @@ public final class ChangeData implements IChangeData {
     private final Set<IRepository> repositories;
 
     ChangeData(final IChangeSource source, final List<? extends ICommit> commits) {
-        this(source, commits, Collections.<File, IRevisionedFile> emptyMap());
+        this(source, commits, Collections.emptyMap());
     }
 
     ChangeData(
@@ -35,11 +36,12 @@ public final class ChangeData implements IChangeData {
 
         this.source = source;
         this.commits = commits;
-        this.localPathMap = localPathMap;
+        this.localPathMap = new LinkedHashMap<>();
+        this.localPathMap.putAll(localPathMap);
 
         this.commits.sort(new Comparator<ICommit>() {
             @Override
-            public int compare(ICommit o1, ICommit o2) {
+            public int compare(final ICommit o1, final ICommit o2) {
                 return o1.getTime().compareTo(o2.getTime());
             }
         });

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ChangestructureFactory.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ChangestructureFactory.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import de.setsoftware.reviewtool.base.IPartiallyComparable;
 import de.setsoftware.reviewtool.model.api.IBinaryChange;
 import de.setsoftware.reviewtool.model.api.IChange;
 import de.setsoftware.reviewtool.model.api.IChangeData;
@@ -46,7 +47,7 @@ public class ChangestructureFactory {
     }
 
     public static ITextualChange createTextualChangeHunk(
-            IWorkingCopy wc,
+            final IWorkingCopy wc,
             final IFragment from,
             final IFragment to,
             final boolean irrelevantForReview) {
@@ -57,11 +58,14 @@ public class ChangestructureFactory {
         return new FileInRevision(path, revision);
     }
 
-    public static IFragment createFragment(IRevisionedFile file, IPositionInText from, IPositionInText to) {
+    public static IFragment createFragment(
+            final IRevisionedFile file,
+            final IPositionInText from,
+            final IPositionInText to) {
         return new Fragment(file, from, to);
     }
 
-    public static IHunk createHunk(IFragment from, IFragment to) {
+    public static IHunk createHunk(final IFragment from, final IFragment to) {
         return new Hunk(from, to);
     }
 
@@ -69,15 +73,17 @@ public class ChangestructureFactory {
         return new LocalRevision(wc);
     }
 
-    public static IRepoRevision createRepoRevision(final Object id, final IRepository repo) {
-        return new RepoRevision(id, repo);
+    public static <R extends IPartiallyComparable<R>> IRepoRevision<R> createRepoRevision(
+            final R id,
+            final IRepository repo) {
+        return new RepoRevision<>(id, repo);
     }
 
     public static IUnknownRevision createUnknownRevision(final IRepository repo) {
         return new UnknownRevision(repo);
     }
 
-    public static IPositionInText createPositionInText(int line, int column) {
+    public static IPositionInText createPositionInText(final int line, final int column) {
         return new PositionInText(line, column);
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileDiff.java
@@ -30,7 +30,7 @@ public final class FileDiff implements IFileDiff {
      */
     private final List<IHunk> hunks;
     private final IRevisionedFile fromRevision;
-    private IRevisionedFile toRevision;
+    private final IRevisionedFile toRevision;
 
     /**
      * Creates an empty FileDiff object that will be filled with hunks.
@@ -63,7 +63,7 @@ public final class FileDiff implements IFileDiff {
     }
 
     @Override
-    public List<? extends IHunk> getHunks() {
+    public List<IHunk> getHunks() {
         return Collections.unmodifiableList(this.hunks);
     }
 
@@ -92,7 +92,7 @@ public final class FileDiff implements IFileDiff {
     }
 
     @Override
-    public List<? extends IHunk> getHunksWithTargetChangesInOneOf(final Collection<? extends IFragment> fragments) {
+    public List<IHunk> getHunksWithTargetChangesInOneOf(final Collection<? extends IFragment> fragments) {
         final List<IHunk> result = new ArrayList<>();
         for (final IHunk hunk : this.hunks) {
             if (hunk.getTarget().containsChangeInOneOf(fragments)) {
@@ -143,7 +143,7 @@ public final class FileDiff implements IFileDiff {
         IFileDiff result = this;
         IDelta delta = new Delta();
         int lastLine = 0;
-        for (IHunk hunk : hunksToMerge) {
+        for (final IHunk hunk : hunksToMerge) {
             delta = delta.ignoreColumnOffset(hunk.getSource().getFrom().getLine() != lastLine);
             result = result.merge(hunk.adjustSource(delta));
             delta = delta.plus(hunk.getDelta());
@@ -288,7 +288,7 @@ public final class FileDiff implements IFileDiff {
      *              or if the resulting target parts cannot be combined into one fragment.
      */
     private IFragment combineTargets(final IHunk hunkToMerge, final IFragmentList targets)
-            throws Error, IncompatibleFragmentException {
+            throws IncompatibleFragmentException {
 
         final IFragmentList adjustedTargets = new FragmentList();
         final IDelta hunkDelta = hunkToMerge.getDelta();

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
@@ -518,10 +518,7 @@ public abstract class FileHistoryGraph extends AbstractFileHistoryGraph implemen
         return this.index.get(file.getPath());
     }
 
-    /**
-     * Returns the nearest ancestor for passed {@link IRevisionedFile} having the same path, or <code>null</code>
-     * if no suitable node exists. To be suitable, the ancestor node must not be deleted.
-     */
+    @Override
     public abstract ProxyableFileHistoryNode findAncestorFor(IRevisionedFile file);
 
     @Override

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileInRevision.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileInRevision.java
@@ -145,6 +145,20 @@ public class FileInRevision implements IRevisionedFile {
             && this.revision.equals(f.revision);
     }
 
+    @Override
+    public boolean le(final IRevisionedFile other) {
+        final IRevision otherRevision = other.getRevision();
+        if (this.revision.le(otherRevision)) {
+            if (otherRevision.le(this.revision)) {
+                return this.path.compareTo(other.getPath()) <= 0;
+            } else {
+                return true;
+            }
+        } else {
+            return false;
+        }
+    }
+
     /**
      * Sorts the given files topologically by their revisions. Per revision, the files are sorted by path.
      * This makes most sense when they all denote different versions of the same file.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileInRevision.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileInRevision.java
@@ -37,7 +37,7 @@ public class FileInRevision implements IRevisionedFile {
     private final String path;
     private final IRevision revision;
 
-    FileInRevision(String path, IRevision revision) {
+    FileInRevision(final String path, final IRevision revision) {
         this.path = path;
         this.revision = revision;
     }
@@ -73,7 +73,7 @@ public class FileInRevision implements IRevisionedFile {
             }
 
             @Override
-            public byte[] handleRepoRevision(final IRepoRevision revision) throws Exception {
+            public byte[] handleRepoRevision(final IRepoRevision<?> revision) throws Exception {
                 return FileInRevision.this.getRepository().getFileContents(FileInRevision.this.path, revision);
             }
 
@@ -136,7 +136,7 @@ public class FileInRevision implements IRevisionedFile {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (!(o instanceof FileInRevision)) {
             return false;
         }
@@ -151,7 +151,7 @@ public class FileInRevision implements IRevisionedFile {
      * For non-comparable revisions, the sort is stable. The earliest revisions come first.
      * Does NOT sort in-place.
      */
-    public static List<? extends IRevisionedFile> sortByRevision(Collection<? extends IRevisionedFile> toSort) {
+    public static List<IRevisionedFile> sortByRevision(final Collection<? extends IRevisionedFile> toSort) {
 
         if (toSort.isEmpty()) {
             return Collections.emptyList();

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Fragment.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Fragment.java
@@ -76,7 +76,10 @@ public final class Fragment implements IFragment {
      * the {@link ChangestructureFactory}.
      */
     public static IFragment createWithContent(
-            IRevisionedFile file, IPositionInText from, IPositionInText to, String content) {
+            final IRevisionedFile file,
+            final IPositionInText from,
+            final IPositionInText to,
+            final String content) {
         final Fragment ret = new Fragment(file, from, to);
         ret.content = content;
         return ret;
@@ -141,7 +144,7 @@ public final class Fragment implements IFragment {
         }
     }
 
-    private static int countCharsInLastLine(String s) {
+    private static int countCharsInLastLine(final String s) {
         int count = s.endsWith("\n") ? 1 : 0;
         for (int i = s.length() - count - 1; i >= 0; i--) {
             if (s.charAt(i) == '\n') {
@@ -252,12 +255,12 @@ public final class Fragment implements IFragment {
     }
 
     @Override
-    public FragmentList subtract(final IFragment other) {
+    public IFragmentList subtract(final IFragment other) {
         if (!this.overlaps(other)) {
             return new FragmentList(this);
         } else {
             try {
-                final FragmentList fragmentList = new FragmentList();
+                final IFragmentList fragmentList = new FragmentList();
                 if (this.from.lessThan(other.getFrom())) {
                     fragmentList.addFragment(new Fragment(this.file, this.from, other.getFrom(), this));
                 }
@@ -317,7 +320,7 @@ public final class Fragment implements IFragment {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final Object obj) {
         if (!(obj instanceof Fragment)) {
             return false;
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FragmentTracer.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FragmentTracer.java
@@ -17,12 +17,16 @@ import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 public class FragmentTracer implements IFragmentTracer {
 
     @Override
-    public List<IFragment> traceFragment(final IFileHistoryGraph fileHistoryGraph, final IFragment fragment) {
+    public List<IFragment> traceFragment(
+            final IFileHistoryGraph fileHistoryGraph,
+            final IFragment fragment,
+            final boolean ignoreNonLocalCopies) {
+
         final ArrayList<IFragment> result = new ArrayList<>();
         final IRevisionedFile file = fragment.getFile();
         final IFileHistoryNode node = fileHistoryGraph.getNodeFor(file);
         if (node != null) {
-            for (final IRevisionedFile leafRevision : fileHistoryGraph.getLatestFiles(file)) {
+            for (final IRevisionedFile leafRevision : fileHistoryGraph.getLatestFiles(file, ignoreNonLocalCopies)) {
                 final IFileHistoryNode descendant = fileHistoryGraph.getNodeFor(leafRevision);
                 final Set<? extends IFileDiff> fileDiffs = descendant.buildHistories(node);
                 for (final IFileDiff fileDiff : fileDiffs) {
@@ -36,11 +40,15 @@ public class FragmentTracer implements IFragmentTracer {
     }
 
     @Override
-    public List<IRevisionedFile> traceFile(final IFileHistoryGraph fileHistoryGraph, final IRevisionedFile file) {
+    public List<IRevisionedFile> traceFile(
+            final IFileHistoryGraph fileHistoryGraph,
+            final IRevisionedFile file,
+            final boolean ignoreNonLocalCopies) {
+
         final ArrayList<IRevisionedFile> result = new ArrayList<>();
         final IFileHistoryNode node = fileHistoryGraph.getNodeFor(file);
         if (node != null) {
-            for (final IRevisionedFile leafRevision : fileHistoryGraph.getLatestFiles(file)) {
+            for (final IRevisionedFile leafRevision : fileHistoryGraph.getLatestFiles(file, ignoreNonLocalCopies)) {
                 result.add(leafRevision);
             }
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Hunk.java
@@ -78,7 +78,7 @@ public final class Hunk implements IHunk {
      * @param hunks The collection of hunks.
      * @return A FragmentList containing all source fragments of the hunks in order. Adjacent fragments are merged.
      */
-    public static IFragmentList getSources(final Collection<? extends Hunk> hunks) {
+    public static IFragmentList getSources(final Collection<? extends IHunk> hunks) {
         final IFragmentList result = new FragmentList();
         for (final IHunk hunk : hunks) {
             try {
@@ -96,7 +96,7 @@ public final class Hunk implements IHunk {
      * @param hunks The collection of hunks.
      * @return A FragmentList containing all target fragments of the hunks in order. Adjacent fragments are merged.
      */
-    public static IFragmentList getTargets(final Collection<? extends Hunk> hunks) {
+    public static IFragmentList getTargets(final Collection<? extends IHunk> hunks) {
         final IFragmentList result = new FragmentList();
         for (final IHunk hunk : hunks) {
             try {
@@ -148,7 +148,7 @@ public final class Hunk implements IHunk {
     }
 
     @Override
-    public Hunk adjustTargetFile(final IRevisionedFile target) {
+    public IHunk adjustTargetFile(final IRevisionedFile target) {
         return new Hunk(this.source, this.target.setFile(target));
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/LocalRevision.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/LocalRevision.java
@@ -2,6 +2,7 @@ package de.setsoftware.reviewtool.model.changestructure;
 
 import de.setsoftware.reviewtool.model.api.ILocalRevision;
 import de.setsoftware.reviewtool.model.api.IRepository;
+import de.setsoftware.reviewtool.model.api.IRevision;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitor;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitorE;
 import de.setsoftware.reviewtool.model.api.IWorkingCopy;
@@ -40,7 +41,7 @@ public final class LocalRevision implements ILocalRevision {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (!(o instanceof LocalRevision)) {
             return false;
         }
@@ -49,12 +50,17 @@ public final class LocalRevision implements ILocalRevision {
     }
 
     @Override
-    public <R> R accept(IRevisionVisitor<R> visitor) {
+    public <R> R accept(final IRevisionVisitor<R> visitor) {
         return visitor.handleLocalRevision(this);
     }
 
     @Override
-    public <R, E extends Throwable> R accept(IRevisionVisitorE<R, E> visitor) throws E {
+    public <R, E extends Throwable> R accept(final IRevisionVisitorE<R, E> visitor) throws E {
         return visitor.handleLocalRevision(this);
+    }
+
+    @Override
+    public boolean le(final IRevision other) {
+        return this.equals(other);
     }
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Stop.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/Stop.java
@@ -138,19 +138,19 @@ public class Stop extends TourElement implements IStop {
     public synchronized void updateMostRecentData(final IFragmentTracer tracer) {
         if (this.mostRecentFragment != null) {
             final List<? extends IFragment> fragments =
-                    tracer.traceFragment(this.wc.getFileHistoryGraph(), this.mostRecentFragment);
+                    tracer.traceFragment(this.wc.getFileHistoryGraph(), this.mostRecentFragment, true);
             for (final IFragment fragment : fragments) {
                 if (this.wc.toAbsolutePathInWc(fragment.getFile().getPath()) != null) {
                     this.mostRecentFragmentConsideringLocalChanges = fragment;
-                    break;
+                    break; // we don't support multiple locally changed files per stop
                 }
             }
         }
-        final List<IRevisionedFile> files = tracer.traceFile(this.wc.getFileHistoryGraph(), this.mostRecentFile);
+        final List<IRevisionedFile> files = tracer.traceFile(this.wc.getFileHistoryGraph(), this.mostRecentFile, true);
         for (final IRevisionedFile file : files) {
             if (this.wc.toAbsolutePathInWc(file.getPath()) != null) {
                 this.mostRecentFileConsideringLocalChanges = file;
-                break;
+                break; // we don't support multiple locally changed files per stop
             }
         }
     }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
@@ -103,8 +103,8 @@ public class ToursInReview {
         private final List<? extends Pair<String, Set<? extends IChange>>> toMakeIrrelevant;
 
         public UserSelectedReductions(
-                List<? extends ICommit> chosenCommitSubset,
-                List<Pair<String, Set<? extends IChange>>> chosenFilterSubset) {
+                final List<? extends ICommit> chosenCommitSubset,
+                final List<Pair<String, Set<? extends IChange>>> chosenFilterSubset) {
             this.commitSubset = chosenCommitSubset;
             this.toMakeIrrelevant = chosenFilterSubset;
         }
@@ -118,19 +118,19 @@ public class ToursInReview {
         private final Date date;
         private final String user;
 
-        public ReviewRoundInfo(int number, Date date, String user) {
+        public ReviewRoundInfo(final int number, final Date date, final String user) {
             this.number = number;
             this.date = date;
             this.user = user;
         }
 
         @Override
-        public int compareTo(ReviewRoundInfo o) {
+        public int compareTo(final ReviewRoundInfo o) {
             return Integer.compare(this.number, o.number);
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (!(o instanceof ReviewRoundInfo)) {
                 return false;
             }
@@ -184,7 +184,7 @@ public class ToursInReview {
     /**
      * Creates a new object with the given tours (mainly for tests).
      */
-    public static ToursInReview create(List<Tour> tours) {
+    public static ToursInReview create(final List<Tour> tours) {
         return new ToursInReview(tours);
     }
 
@@ -196,12 +196,12 @@ public class ToursInReview {
     public static ToursInReview create(
             final ChangeManager changeManager,
             final IChangeSourceUi changeSourceUi,
-            List<? extends IIrrelevanceDetermination> irrelevanceDeterminationStrategies,
-            List<? extends ITourRestructuring> tourRestructuringStrategies,
-            IStopOrdering orderingAlgorithm,
-            ICreateToursUi createUi,
-            IChangeData changes,
-            List<ReviewRoundInfo> reviewRounds) {
+            final List<? extends IIrrelevanceDetermination> irrelevanceDeterminationStrategies,
+            final List<? extends ITourRestructuring> tourRestructuringStrategies,
+            final IStopOrdering orderingAlgorithm,
+            final ICreateToursUi createUi,
+            final IChangeData changes,
+            final List<ReviewRoundInfo> reviewRounds) {
         changeSourceUi.subTask("Filtering changes...");
         final List<? extends ICommit> filteredChanges =
                 filterChanges(irrelevanceDeterminationStrategies, changes.getMatchedCommits(),
@@ -244,7 +244,10 @@ public class ToursInReview {
     }
 
     private static List<? extends Tour> groupAndSort(
-            List<? extends Tour> userSelection, IStopOrdering orderingAlgorithm, TourCalculatorControl isCanceled) {
+            final List<? extends Tour> userSelection,
+            final IStopOrdering orderingAlgorithm,
+            final TourCalculatorControl isCanceled) {
+
         try {
             final List<Tour> ret = new ArrayList<>();
             for (final Tour t : userSelection) {
@@ -335,7 +338,7 @@ public class ToursInReview {
         return ret;
     }
 
-    private static int countChanges(List<? extends ICommit> changes, boolean onlyRelevant) {
+    private static int countChanges(final List<? extends ICommit> changes, final boolean onlyRelevant) {
         int ret = 0;
         for (final ICommit commit : changes) {
             for (final IChange change : commit.getChanges()) {
@@ -348,8 +351,8 @@ public class ToursInReview {
     }
 
     private static Set<? extends IChange> determineIrrelevantChanges(
-            List<? extends ICommit> changes,
-            IIrrelevanceDetermination strategy) {
+            final List<? extends ICommit> changes,
+            final IIrrelevanceDetermination strategy) {
 
         final Set<IChange> ret = new HashSet<>();
         for (final ICommit commit : changes) {
@@ -362,7 +365,7 @@ public class ToursInReview {
         return ret;
     }
 
-    private static boolean areAllIrrelevant(Set<? extends IChange> changes) {
+    private static boolean areAllIrrelevant(final Set<? extends IChange> changes) {
         for (final IChange change : changes) {
             if (!change.isIrrelevantForReview()) {
                 return false;
@@ -425,7 +428,7 @@ public class ToursInReview {
         return ret;
     }
 
-    private static List<Stop> toSliceFragments(List<? extends IChange> changes, IFragmentTracer tracer) {
+    private static List<Stop> toSliceFragments(final List<? extends IChange> changes, final IFragmentTracer tracer) {
         final List<Stop> ret = new ArrayList<>();
         for (final IChange c : changes) {
             ret.addAll(toSliceFragment(c, tracer));
@@ -433,15 +436,15 @@ public class ToursInReview {
         return ret;
     }
 
-    private static List<Stop> toSliceFragment(IChange c, final IFragmentTracer tracer) {
+    private static List<Stop> toSliceFragment(final IChange c, final IFragmentTracer tracer) {
         final List<Stop> ret = new ArrayList<>();
         c.accept(new IChangeVisitor() {
 
             @Override
-            public void handle(ITextualChange visitee) {
+            public void handle(final ITextualChange visitee) {
                 final IWorkingCopy wc = c.getWorkingCopy();
                 final List<? extends IFragment> mostRecentFragments =
-                        tracer.traceFragment(wc.getFileHistoryGraph(), visitee.getToFragment());
+                        tracer.traceFragment(wc.getRepository().getFileHistoryGraph(), visitee.getToFragment());
                 for (final IFragment fragment : mostRecentFragments) {
                     if (wc.toAbsolutePathInWc(fragment.getFile().getPath()) != null) {
                         ret.add(new Stop(visitee, fragment));
@@ -450,10 +453,10 @@ public class ToursInReview {
             }
 
             @Override
-            public void handle(IBinaryChange visitee) {
+            public void handle(final IBinaryChange visitee) {
                 final IWorkingCopy wc = c.getWorkingCopy();
                 for (final IRevisionedFile fileInRevision :
-                        tracer.traceFile(wc.getFileHistoryGraph(), visitee.getFrom())) {
+                        tracer.traceFile(wc.getRepository().getFileHistoryGraph(), visitee.getFrom())) {
                     if (wc.toAbsolutePathInWc(fileInRevision.getPath()) != null) {
                         ret.add(new Stop(visitee, fileInRevision));
                     }
@@ -481,7 +484,7 @@ public class ToursInReview {
     }
 
     private IMarker createMarkerFor(
-            IStopMarkerFactory markerFactory,
+            final IStopMarkerFactory markerFactory,
             final Map<IResource, PositionLookupTable> lookupTables,
             final Stop f,
             final boolean tourActive) {
@@ -518,7 +521,7 @@ public class ToursInReview {
      * is returned.
      */
     public IMarker createMarkerFor(
-            IStopMarkerFactory markerFactory,
+            final IStopMarkerFactory markerFactory,
             final Stop f) {
         return this.createMarkerFor(markerFactory, new HashMap<IResource, PositionLookupTable>(), f, true);
     }
@@ -531,7 +534,7 @@ public class ToursInReview {
      * Sets the given tour as the active tour, if it is not already active.
      * Recreates markers accordingly.
      */
-    public void ensureTourActive(Tour t, IStopMarkerFactory markerFactory) {
+    public void ensureTourActive(final Tour t, final IStopMarkerFactory markerFactory) {
         this.ensureTourActive(t, markerFactory, true);
     }
 
@@ -539,7 +542,7 @@ public class ToursInReview {
      * Sets the given tour as the active tour, if it is not already active.
      * Recreates markers accordingly.
      */
-    public void ensureTourActive(Tour t, final IStopMarkerFactory markerFactory, boolean notify) {
+    public void ensureTourActive(final Tour t, final IStopMarkerFactory markerFactory, final boolean notify) {
 
         final int index = this.topmostTours.indexOf(t);
         if (index != this.currentTourIndex) {
@@ -547,7 +550,7 @@ public class ToursInReview {
             this.currentTourIndex = index;
             new WorkspaceJob("Review marker update") {
                 @Override
-                public IStatus runInWorkspace(IProgressMonitor progressMonitor) throws CoreException {
+                public IStatus runInWorkspace(final IProgressMonitor progressMonitor) throws CoreException {
                     ToursInReview.this.clearMarkers();
                     ToursInReview.this.createMarkers(markerFactory, progressMonitor);
                     return Status.OK_STATUS;
@@ -581,14 +584,14 @@ public class ToursInReview {
                 ? null : this.topmostTours.get(this.currentTourIndex);
     }
 
-    public void registerListener(IToursInReviewChangeListener listener) {
+    public void registerListener(final IToursInReviewChangeListener listener) {
         this.listeners.add(listener);
     }
 
     /**
      * Returns all stops (from all tours) that refer to the given file.
      */
-    public List<Stop> getStopsFor(File absolutePath) {
+    public List<Stop> getStopsFor(final File absolutePath) {
         final List<Stop> ret = new ArrayList<>();
         for (final Tour t : this.topmostTours) {
             for (final Stop s : t.getStops()) {
@@ -604,7 +607,7 @@ public class ToursInReview {
      * Returns the (first) tour that contains the given stop.
      * If none exists, -1 is returned.
      */
-    public int findTourIndexWithStop(Stop currentStop) {
+    public int findTourIndexWithStop(final Stop currentStop) {
         for (int i = 0; i < this.topmostTours.size(); i++) {
             for (final Stop s : this.topmostTours.get(i).getStops()) {
                 if (s == currentStop) {
@@ -620,7 +623,7 @@ public class ToursInReview {
      * The closeness measure is tweaked to (hopefully) capture the users intention as good as possible
      * for cases where he did not click directly on a stop.
      */
-    public Pair<Tour, Stop> findNearestStop(IPath absoluteResourcePath, int line) {
+    public Pair<Tour, Stop> findNearestStop(final IPath absoluteResourcePath, final int line) {
         if (this.topmostTours.isEmpty()) {
             return null;
         }
@@ -640,7 +643,7 @@ public class ToursInReview {
         return Pair.create(bestTour, bestStop);
     }
 
-    private int calculateDistance(Stop stop, IPath resource, int line) {
+    private int calculateDistance(final Stop stop, final IPath resource, final int line) {
         if (!stop.getMostRecentFile().toLocalPath(stop.getWorkingCopy()).equals(resource)) {
             return Integer.MAX_VALUE;
         }
@@ -665,7 +668,7 @@ public class ToursInReview {
      * Determines the direct parent tour of the given element.
      * Returns null when none is found.
      */
-    public Tour getParentFor(TourElement element) {
+    public Tour getParentFor(final TourElement element) {
         for (final Tour t : this.topmostTours) {
             final Tour parent = t.findParentFor(element);
             if (parent != null) {
@@ -679,7 +682,7 @@ public class ToursInReview {
      * Determines the topmost parent tour of the given element.
      * Returns null when none is found.
      */
-    public Tour getTopmostTourWith(TourElement element) {
+    public Tour getTopmostTourWith(final TourElement element) {
         for (final Tour t : this.topmostTours) {
             final Tour parent = t.findParentFor(element);
             if (parent != null) {

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ToursInReview.java
@@ -444,7 +444,7 @@ public class ToursInReview {
             public void handle(final ITextualChange visitee) {
                 final IWorkingCopy wc = c.getWorkingCopy();
                 final List<? extends IFragment> mostRecentFragments =
-                        tracer.traceFragment(wc.getRepository().getFileHistoryGraph(), visitee.getToFragment());
+                        tracer.traceFragment(wc.getRepository().getFileHistoryGraph(), visitee.getToFragment(), false);
                 for (final IFragment fragment : mostRecentFragments) {
                     if (wc.toAbsolutePathInWc(fragment.getFile().getPath()) != null) {
                         ret.add(new Stop(visitee, fragment));
@@ -456,7 +456,7 @@ public class ToursInReview {
             public void handle(final IBinaryChange visitee) {
                 final IWorkingCopy wc = c.getWorkingCopy();
                 for (final IRevisionedFile fileInRevision :
-                        tracer.traceFile(wc.getRepository().getFileHistoryGraph(), visitee.getFrom())) {
+                        tracer.traceFile(wc.getRepository().getFileHistoryGraph(), visitee.getFrom(), false)) {
                     if (wc.toAbsolutePathInWc(fileInRevision.getPath()) != null) {
                         ret.add(new Stop(visitee, fileInRevision));
                     }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/UnknownRevision.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/UnknownRevision.java
@@ -1,6 +1,7 @@
 package de.setsoftware.reviewtool.model.changestructure;
 
 import de.setsoftware.reviewtool.model.api.IRepository;
+import de.setsoftware.reviewtool.model.api.IRevision;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitor;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitorE;
 import de.setsoftware.reviewtool.model.api.IUnknownRevision;
@@ -34,7 +35,7 @@ public final class UnknownRevision implements IUnknownRevision {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (!(o instanceof UnknownRevision)) {
             return false;
         }
@@ -43,12 +44,17 @@ public final class UnknownRevision implements IUnknownRevision {
     }
 
     @Override
-    public <R> R accept(IRevisionVisitor<R> visitor) {
+    public <R> R accept(final IRevisionVisitor<R> visitor) {
         return visitor.handleUnknownRevision(this);
     }
 
     @Override
-    public <R, E extends Throwable> R accept(IRevisionVisitorE<R, E> visitor) throws E {
+    public <R, E extends Throwable> R accept(final IRevisionVisitorE<R, E> visitor) throws E {
         return visitor.handleUnknownRevision(this);
+    }
+
+    @Override
+    public boolean le(final IRevision other) {
+        return !(other instanceof IUnknownRevision) || this.equals(other);
     }
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraph.java
@@ -1,7 +1,9 @@
 package de.setsoftware.reviewtool.model.changestructure;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import de.setsoftware.reviewtool.model.api.IDiffAlgorithm;
 import de.setsoftware.reviewtool.model.api.IFileHistoryGraph;
@@ -56,6 +58,14 @@ public final class VirtualFileHistoryGraph extends AbstractFileHistoryGraph {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public final Set<IFileHistoryNode> getIncompleteFlowStarts() {
+        final Set<IFileHistoryNode> result = new LinkedHashSet<>();
+        result.addAll(this.remoteFileHistoryGraph.getIncompleteFlowStarts());
+        result.addAll(this.localFileHistoryGraph.getIncompleteFlowStarts());
+        return result;
     }
 
     /**

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraph.java
@@ -1,10 +1,16 @@
 package de.setsoftware.reviewtool.model.changestructure;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import de.setsoftware.reviewtool.base.Multimap;
+import de.setsoftware.reviewtool.base.PartialOrderAlgorithms;
 import de.setsoftware.reviewtool.model.api.IDiffAlgorithm;
 import de.setsoftware.reviewtool.model.api.IFileHistoryGraph;
 import de.setsoftware.reviewtool.model.api.IFileHistoryNode;
@@ -19,17 +25,60 @@ public final class VirtualFileHistoryGraph extends AbstractFileHistoryGraph {
 
     private final IFileHistoryGraph remoteFileHistoryGraph;
     private IFileHistoryGraph localFileHistoryGraph;
+    private Map<IRevisionedFile, IFileHistoryNode> virtualNodes;
 
-    public VirtualFileHistoryGraph(
-            final IFileHistoryGraph remoteFileHistoryGraph,
-            final IFileHistoryGraph localFileHistoryGraph) {
-
+    public VirtualFileHistoryGraph(final IFileHistoryGraph remoteFileHistoryGraph) {
         this.remoteFileHistoryGraph = remoteFileHistoryGraph;
-        this.localFileHistoryGraph = localFileHistoryGraph;
+        this.localFileHistoryGraph = null;
+        this.virtualNodes = new LinkedHashMap<>();
     }
 
+    /**
+     * Sets or unsets the local file history graph.
+     * @param localFileHistoryGraph The new local file history graph. May be {@code null}.
+     */
     public void setLocalFileHistoryGraph(final IFileHistoryGraph localFileHistoryGraph) {
         this.localFileHistoryGraph = localFileHistoryGraph;
+        this.virtualNodes.clear();
+        if (this.localFileHistoryGraph != null) {
+            this.computeIntermediateNodes();
+        }
+    }
+
+    private void computeIntermediateNodes() {
+        for (final IFileHistoryNode localNode : this.localFileHistoryGraph.getIncompleteFlowStarts()) {
+            this.computeIntermediateNodes(localNode);
+        }
+    }
+
+    private void computeIntermediateNodes(final IFileHistoryNode localNode) {
+        IFileHistoryNode remoteNode = this.remoteFileHistoryGraph.getNodeFor(localNode.getFile());
+        if (remoteNode != null) {
+            final VirtualFileHistoryNode virtualNode = new VirtualFileHistoryNode(
+                    this,
+                    localNode.getFile(),
+                    Arrays.asList(remoteNode, localNode));
+            this.virtualNodes.put(virtualNode.getFile(), virtualNode);
+            return;
+        }
+
+        remoteNode = this.remoteFileHistoryGraph.findAncestorFor(localNode.getFile());
+        if (remoteNode != null) {
+            final VirtualFileHistoryNode virtualAncestorNode = new VirtualFileHistoryNode(
+                    this,
+                    remoteNode.getFile(),
+                    Collections.singletonList(remoteNode));
+            final VirtualFileHistoryNode virtualDescendantNode = new VirtualFileHistoryNode(
+                    this,
+                    localNode.getFile(),
+                    Collections.singletonList(localNode));
+
+            virtualAncestorNode.addDescendant(virtualDescendantNode);
+            virtualDescendantNode.addAncestor(virtualAncestorNode);
+
+            this.virtualNodes.put(virtualAncestorNode.getFile(), virtualAncestorNode);
+            this.virtualNodes.put(virtualDescendantNode.getFile(), virtualDescendantNode);
+        }
     }
 
     @Override
@@ -40,6 +89,11 @@ public final class VirtualFileHistoryGraph extends AbstractFileHistoryGraph {
 
     @Override
     public IFileHistoryNode getNodeFor(final IRevisionedFile file) {
+        final IFileHistoryNode virtualNode = this.virtualNodes.get(file);
+        if (virtualNode != null) {
+            return virtualNode;
+        }
+
         final List<IFileHistoryNode> nodes = new ArrayList<>();
 
         final IFileHistoryNode remoteNode = this.remoteFileHistoryGraph.getNodeFor(file);
@@ -47,7 +101,9 @@ public final class VirtualFileHistoryGraph extends AbstractFileHistoryGraph {
             nodes.add(remoteNode);
         }
 
-        final IFileHistoryNode localNode = this.localFileHistoryGraph.getNodeFor(file);
+        final IFileHistoryNode localNode = this.localFileHistoryGraph != null
+                ? this.localFileHistoryGraph.getNodeFor(file)
+                : null;
         if (localNode != null) {
             nodes.add(localNode);
         }
@@ -55,6 +111,29 @@ public final class VirtualFileHistoryGraph extends AbstractFileHistoryGraph {
         if (!nodes.isEmpty()) {
             final VirtualFileHistoryNode node = new VirtualFileHistoryNode(this, file, nodes);
             return node;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public IFileHistoryNode findAncestorFor(final IRevisionedFile file) {
+        final Multimap<IRevisionedFile, IFileHistoryNode> nodeMap = new Multimap<>();
+
+        final IFileHistoryNode remoteAncestor = this.remoteFileHistoryGraph.findAncestorFor(file);
+        if (remoteAncestor != null) {
+            nodeMap.put(remoteAncestor.getFile(), remoteAncestor);
+        }
+
+        final IFileHistoryNode localAncestor = this.localFileHistoryGraph.findAncestorFor(file);
+        if (localAncestor != null) {
+            nodeMap.put(localAncestor.getFile(), localAncestor);
+        }
+
+        if (!nodeMap.isEmpty()) {
+            final List<IRevisionedFile> sortedFiles = PartialOrderAlgorithms.topoSort(nodeMap.keySet());
+            final List<IFileHistoryNode> nodes = nodeMap.get(sortedFiles.get(sortedFiles.size() - 1));
+            return new VirtualFileHistoryNode(this, file, nodes);
         } else {
             return null;
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryNode.java
@@ -117,19 +117,19 @@ final class VirtualFileHistoryNode extends AbstractFileHistoryNode {
                 ancestorFile.getRevision().accept(new IRevisionVisitor<Void>() {
 
                     @Override
-                    public Void handleLocalRevision(ILocalRevision revision) {
+                    public Void handleLocalRevision(final ILocalRevision revision) {
                         edges.add(edge);
                         return null;
                     }
 
                     @Override
-                    public Void handleRepoRevision(IRepoRevision revision) {
+                    public Void handleRepoRevision(final IRepoRevision<?> revision) {
                         edges.add(edge);
                         return null;
                     }
 
                     @Override
-                    public Void handleUnknownRevision(IUnknownRevision revision) {
+                    public Void handleUnknownRevision(final IUnknownRevision revision) {
                         alphaEdges.add(edge);
                         return null;
                     }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/ui/views/CombinedDiffStopViewer.java
@@ -36,6 +36,7 @@ import org.eclipse.ui.IViewPart;
 
 import de.setsoftware.reviewtool.base.LineSequence;
 import de.setsoftware.reviewtool.base.Pair;
+import de.setsoftware.reviewtool.base.PartialOrderAlgorithms;
 import de.setsoftware.reviewtool.base.ReviewtoolException;
 import de.setsoftware.reviewtool.diffalgorithms.DiffAlgorithmFactory;
 import de.setsoftware.reviewtool.model.Constants;
@@ -46,7 +47,6 @@ import de.setsoftware.reviewtool.model.api.IFragment;
 import de.setsoftware.reviewtool.model.api.IHunk;
 import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 import de.setsoftware.reviewtool.model.api.IStop;
-import de.setsoftware.reviewtool.model.changestructure.FileInRevision;
 
 /**
  * Displays all differences of a {@link IStop} combined in a single window.
@@ -354,7 +354,7 @@ public class CombinedDiffStopViewer implements IStopViewer {
 
     private static final int CONTEXT_LENGTH = 3;
 
-    private List<? extends IRevisionedFile> allRevisions;
+    private List<IRevisionedFile> allRevisions;
     private Combo comboLeft;
     private Combo comboRight;
     private SelectableMergeViewer viewer;
@@ -389,7 +389,7 @@ public class CombinedDiffStopViewer implements IStopViewer {
         final Set<IRevisionedFile> revisionsForStop = new LinkedHashSet<>();
         revisionsForStop.addAll(stop.getHistory().keySet());
         revisionsForStop.addAll(stop.getHistory().values());
-        final List<? extends IRevisionedFile> sortedStopRevisions = FileInRevision.sortByRevision(revisionsForStop);
+        final List<IRevisionedFile> sortedStopRevisions = PartialOrderAlgorithms.topoSort(revisionsForStop);
         final IRevisionedFile initialLeftRevision = sortedStopRevisions.get(0);
         final IRevisionedFile initialRightRevision = sortedStopRevisions.get(sortedStopRevisions.size() - 1);
 
@@ -525,12 +525,12 @@ public class CombinedDiffStopViewer implements IStopViewer {
         }
     }
 
-    private List<? extends IRevisionedFile> determineAllRevisionsOfFile(final IStop stop) {
+    private List<IRevisionedFile> determineAllRevisionsOfFile(final IStop stop) {
         final IRevisionedFile lastRevision = stop.getOriginalMostRecentFile();
         final IFileHistoryNode node = stop.getWorkingCopy().getFileHistoryGraph().getNodeFor(lastRevision);
         final LinkedHashSet<IRevisionedFile> filesBuffer = new LinkedHashSet<>();
         this.determineAllRevisionsOfFileRec(node, filesBuffer);
-        return FileInRevision.sortByRevision(filesBuffer);
+        return PartialOrderAlgorithms.topoSort(filesBuffer);
     }
 
     private void determineAllRevisionsOfFileRec(final IFileHistoryNode node, final Set<IRevisionedFile> buffer) {

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/ComparableWrapperTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/ComparableWrapperTest.java
@@ -1,0 +1,58 @@
+package de.setsoftware.reviewtool.base;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ComparableWrapper}.
+ */
+public class ComparableWrapperTest {
+
+    @Test
+    public void testEquals() {
+        final ComparableWrapper<Long> l1 = ComparableWrapper.wrap(1L);
+        final ComparableWrapper<Long> l2 = ComparableWrapper.wrap(2L);
+        final ComparableWrapper<Integer> i2 = ComparableWrapper.wrap(2);
+
+        assertThat(l1, is(equalTo(l1)));
+        assertThat(l1, is(equalTo(ComparableWrapper.wrap(1L))));
+
+        assertThat(l1, is(not(equalTo(l2))));
+        assertThat(l2, is(not(equalTo(l1))));
+        assertThat(l2, is(not(equalTo(i2))));
+        assertThat(i2, is(not(equalTo(l2))));
+    }
+
+    @Test
+    public void testHashCode() {
+        final ComparableWrapper<Long> l1 = ComparableWrapper.wrap(1L);
+        final ComparableWrapper<Integer> i2 = ComparableWrapper.wrap(2);
+
+        assertThat(l1.hashCode(), is(equalTo(l1.getWrappedComparable().hashCode())));
+        assertThat(i2.hashCode(), is(equalTo(i2.getWrappedComparable().hashCode())));
+    }
+
+    @Test
+    public void testToString() {
+        final ComparableWrapper<Long> l1 = ComparableWrapper.wrap(1L);
+        final ComparableWrapper<Integer> i2 = ComparableWrapper.wrap(2);
+
+        assertThat(l1.toString(), is(equalTo(l1.getWrappedComparable().toString())));
+        assertThat(i2.toString(), is(equalTo(i2.getWrappedComparable().toString())));
+    }
+
+    @Test
+    public void testLessOrEqualOnTotalOrder() {
+        final ComparableWrapper<Long> l1 = ComparableWrapper.wrap(1L);
+        final ComparableWrapper<Long> l2 = ComparableWrapper.wrap(2L);
+
+        assertThat(l1.le(l1), is(equalTo(true)));
+        assertThat(l1.le(l2), is(equalTo(true)));
+        assertThat(l2.le(l1), is(equalTo(false)));
+        assertThat(l2.le(l2), is(equalTo(true)));
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithmsTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithmsTest.java
@@ -1,0 +1,102 @@
+package de.setsoftware.reviewtool.base;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests algorithms operating on partially ordered collections.
+ */
+public class PartialOrderAlgorithmsTest {
+
+    /**
+     * Represents numbers partially ordered by divisor ordering.
+     */
+    private final class MyNumber implements IPartiallyComparable<MyNumber> {
+        private final long value;
+
+        MyNumber(final long value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean le(final MyNumber other) {
+            return other.value % this.value == 0;
+        }
+    }
+
+    @Test
+    public void testGetSomeMinimum() {
+        final MyNumber n1 = new MyNumber(1L);
+        final MyNumber n2 = new MyNumber(2L);
+        final MyNumber n3 = new MyNumber(3L);
+        final MyNumber n4 = new MyNumber(4L);
+
+        final List<MyNumber> numbers = new ArrayList<>();
+        numbers.addAll(Arrays.asList(n1, n2, n3, n4));
+        assertThat(PartialOrderAlgorithms.getSomeMinimum(numbers), is(equalTo(n1)));
+
+        numbers.remove(n1);
+        assertThat(PartialOrderAlgorithms.getSomeMinimum(numbers), anyOf(
+                is(equalTo(n2)),
+                is(equalTo(n3))));
+
+        numbers.remove(n3);
+        assertThat(PartialOrderAlgorithms.getSomeMinimum(numbers), is(equalTo(n2)));
+
+        numbers.remove(n2);
+        assertThat(PartialOrderAlgorithms.getSomeMinimum(numbers), is(equalTo(n4)));
+
+        numbers.remove(n4);
+        assertThat(PartialOrderAlgorithms.getSomeMinimum(numbers), is(nullValue()));
+    }
+
+    @Test
+    public void testTopoSortSortedSet() {
+        final MyNumber n1 = new MyNumber(1L);
+        final MyNumber n2 = new MyNumber(2L);
+        final MyNumber n3 = new MyNumber(3L);
+        final MyNumber n4 = new MyNumber(4L);
+
+        final List<MyNumber> numbers = new ArrayList<>();
+        numbers.addAll(Arrays.asList(n1, n2, n3, n4));
+        assertThat(PartialOrderAlgorithms.topoSort(numbers), is(equalTo(numbers)));
+    }
+
+    @Test
+    public void testTopoSortUnsortedSetWithLeastElement() {
+        final MyNumber n1 = new MyNumber(1L);
+        final MyNumber n2 = new MyNumber(2L);
+        final MyNumber n3 = new MyNumber(3L);
+        final MyNumber n4 = new MyNumber(4L);
+
+        final List<MyNumber> numbers = new ArrayList<>();
+        numbers.addAll(Arrays.asList(n4, n3, n2, n1));
+        assertThat(PartialOrderAlgorithms.topoSort(numbers), anyOf(
+                is(equalTo(Arrays.asList(n1, n2, n3, n4))),
+                is(equalTo(Arrays.asList(n1, n2, n4, n3))),
+                is(equalTo(Arrays.asList(n1, n3, n2, n4)))));
+    }
+
+    @Test
+    public void testTopoSortUnsortedSetWithNoLeastElement() {
+        final MyNumber n2 = new MyNumber(2L);
+        final MyNumber n3 = new MyNumber(3L);
+        final MyNumber n4 = new MyNumber(4L);
+
+        final List<MyNumber> numbers = new ArrayList<>();
+        numbers.addAll(Arrays.asList(n4, n3, n2));
+        assertThat(PartialOrderAlgorithms.topoSort(numbers), anyOf(
+                is(equalTo(Arrays.asList(n2, n3, n4))),
+                is(equalTo(Arrays.asList(n2, n4, n3))),
+                is(equalTo(Arrays.asList(n3, n2, n4)))));
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileDiffTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IFileDiff;
 import de.setsoftware.reviewtool.model.api.IFragment;
 import de.setsoftware.reviewtool.model.api.IFragmentList;
@@ -19,11 +20,11 @@ import de.setsoftware.reviewtool.model.api.IncompatibleFragmentException;
  */
 public class FileDiffTest {
 
-    private static FileInRevision file(String name, int revision) {
-        return new FileInRevision(name, new RepoRevision(revision, StubRepo.INSTANCE));
+    private static FileInRevision file(final String name, final int revision) {
+        return new FileInRevision(name, new RepoRevision<>(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
-    private static PositionInText pos(int line, int col) {
+    private static PositionInText pos(final int line, final int col) {
         return new PositionInText(line, col);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileInRevisionTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileInRevisionTest.java
@@ -1,0 +1,203 @@
+package de.setsoftware.reviewtool.model.changestructure;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import de.setsoftware.reviewtool.base.ComparableWrapper;
+import de.setsoftware.reviewtool.base.PartialOrderAlgorithms;
+import de.setsoftware.reviewtool.model.api.IRevision;
+import de.setsoftware.reviewtool.model.api.IRevisionedFile;
+
+/**
+ * Tests {@link FileInRevision}.
+ */
+public class FileInRevisionTest {
+
+    @Test
+    public void testTotalOrder() {
+        final IRevision u = ChangestructureFactory.createUnknownRevision(StubRepo.INSTANCE);
+        final IRevision r1 = ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(1), StubRepo.INSTANCE);
+        final IRevision r2 = ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2), StubRepo.INSTANCE);
+        final IRevision l = ChangestructureFactory.createLocalRevision(StubWorkingCopy.INSTANCE);
+
+        final IRevisionedFile fU_a = ChangestructureFactory.createFileInRevision("/a", u);
+        final IRevisionedFile fU_b = ChangestructureFactory.createFileInRevision("/b", u);
+        final IRevisionedFile fR1_a = ChangestructureFactory.createFileInRevision("/a", r1);
+        final IRevisionedFile fR1_b = ChangestructureFactory.createFileInRevision("/b", r1);
+        final IRevisionedFile fR2_a = ChangestructureFactory.createFileInRevision("/a", r2);
+        final IRevisionedFile fR2_b = ChangestructureFactory.createFileInRevision("/b", r2);
+        final IRevisionedFile fL_a = ChangestructureFactory.createFileInRevision("/a", l);
+        final IRevisionedFile fL_b = ChangestructureFactory.createFileInRevision("/b", l);
+
+        assertThat(fU_a.le(fU_a), is(equalTo(true)));
+        assertThat(fU_a.le(fU_b), is(equalTo(true)));
+        assertThat(fU_a.le(fR1_a), is(equalTo(true)));
+        assertThat(fU_a.le(fR1_b), is(equalTo(true)));
+        assertThat(fU_a.le(fR2_a), is(equalTo(true)));
+        assertThat(fU_a.le(fR2_b), is(equalTo(true)));
+        assertThat(fU_a.le(fL_a), is(equalTo(true)));
+        assertThat(fU_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fU_b.le(fU_a), is(equalTo(false)));
+        assertThat(fU_b.le(fU_b), is(equalTo(true)));
+        assertThat(fU_b.le(fR1_a), is(equalTo(true)));
+        assertThat(fU_b.le(fR1_b), is(equalTo(true)));
+        assertThat(fU_b.le(fR2_a), is(equalTo(true)));
+        assertThat(fU_b.le(fR2_b), is(equalTo(true)));
+        assertThat(fU_b.le(fL_a), is(equalTo(true)));
+        assertThat(fU_b.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR1_a.le(fU_a), is(equalTo(false)));
+        assertThat(fR1_a.le(fU_b), is(equalTo(false)));
+        assertThat(fR1_a.le(fR1_a), is(equalTo(true)));
+        assertThat(fR1_a.le(fR1_b), is(equalTo(true)));
+        assertThat(fR1_a.le(fR2_a), is(equalTo(true)));
+        assertThat(fR1_a.le(fR2_b), is(equalTo(true)));
+        assertThat(fR1_a.le(fL_a), is(equalTo(true)));
+        assertThat(fR1_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR1_b.le(fU_a), is(equalTo(false)));
+        assertThat(fR1_b.le(fU_b), is(equalTo(false)));
+        assertThat(fR1_b.le(fR1_a), is(equalTo(false)));
+        assertThat(fR1_b.le(fR1_b), is(equalTo(true)));
+        assertThat(fR1_b.le(fR2_a), is(equalTo(true)));
+        assertThat(fR1_b.le(fR2_b), is(equalTo(true)));
+        assertThat(fR1_b.le(fL_a), is(equalTo(true)));
+        assertThat(fR1_b.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR2_a.le(fU_a), is(equalTo(false)));
+        assertThat(fR2_a.le(fU_b), is(equalTo(false)));
+        assertThat(fR2_a.le(fR1_a), is(equalTo(false)));
+        assertThat(fR2_a.le(fR1_b), is(equalTo(false)));
+        assertThat(fR2_a.le(fR2_a), is(equalTo(true)));
+        assertThat(fR2_a.le(fR2_b), is(equalTo(true)));
+        assertThat(fR2_a.le(fL_a), is(equalTo(true)));
+        assertThat(fR2_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR2_b.le(fU_a), is(equalTo(false)));
+        assertThat(fR2_b.le(fU_b), is(equalTo(false)));
+        assertThat(fR2_b.le(fR1_a), is(equalTo(false)));
+        assertThat(fR2_b.le(fR1_b), is(equalTo(false)));
+        assertThat(fR2_b.le(fR2_a), is(equalTo(false)));
+        assertThat(fR2_b.le(fR2_b), is(equalTo(true)));
+        assertThat(fR2_b.le(fL_a), is(equalTo(true)));
+        assertThat(fR2_b.le(fL_b), is(equalTo(true)));
+
+        assertThat(fL_a.le(fU_a), is(equalTo(false)));
+        assertThat(fL_a.le(fU_b), is(equalTo(false)));
+        assertThat(fL_a.le(fR1_a), is(equalTo(false)));
+        assertThat(fL_a.le(fR1_b), is(equalTo(false)));
+        assertThat(fL_a.le(fR2_a), is(equalTo(false)));
+        assertThat(fL_a.le(fR2_b), is(equalTo(false)));
+        assertThat(fL_a.le(fL_a), is(equalTo(true)));
+        assertThat(fL_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fL_b.le(fU_a), is(equalTo(false)));
+        assertThat(fL_b.le(fU_b), is(equalTo(false)));
+        assertThat(fL_b.le(fR1_a), is(equalTo(false)));
+        assertThat(fL_b.le(fR1_b), is(equalTo(false)));
+        assertThat(fL_b.le(fR2_a), is(equalTo(false)));
+        assertThat(fL_b.le(fR2_b), is(equalTo(false)));
+        assertThat(fL_b.le(fL_a), is(equalTo(false)));
+        assertThat(fL_b.le(fL_b), is(equalTo(true)));
+    }
+
+    @Test
+    public void testPartialOrder() {
+        final IRevision u = ChangestructureFactory.createUnknownRevision(PartiallyOrderedRepo.INSTANCE);
+        final IRevision r1 = ChangestructureFactory.createRepoRevision(new PartiallyOrderedID("abcd"),
+                PartiallyOrderedRepo.INSTANCE);
+        final IRevision r2 = ChangestructureFactory.createRepoRevision(new PartiallyOrderedID("efgh"),
+                PartiallyOrderedRepo.INSTANCE);
+        final IRevision l = ChangestructureFactory.createLocalRevision(PartiallyOrderedWorkingCopy.INSTANCE);
+
+        final IRevisionedFile fU_a = ChangestructureFactory.createFileInRevision("/a", u);
+        final IRevisionedFile fU_b = ChangestructureFactory.createFileInRevision("/b", u);
+        final IRevisionedFile fR1_a = ChangestructureFactory.createFileInRevision("/a", r1);
+        final IRevisionedFile fR1_b = ChangestructureFactory.createFileInRevision("/b", r1);
+        final IRevisionedFile fR2_a = ChangestructureFactory.createFileInRevision("/a", r2);
+        final IRevisionedFile fR2_b = ChangestructureFactory.createFileInRevision("/b", r2);
+        final IRevisionedFile fL_a = ChangestructureFactory.createFileInRevision("/a", l);
+        final IRevisionedFile fL_b = ChangestructureFactory.createFileInRevision("/b", l);
+
+        assertThat(fU_a.le(fU_a), is(equalTo(true)));
+        assertThat(fU_a.le(fU_b), is(equalTo(true)));
+        assertThat(fU_a.le(fR1_a), is(equalTo(true)));
+        assertThat(fU_a.le(fR1_b), is(equalTo(true)));
+        assertThat(fU_a.le(fR2_a), is(equalTo(true)));
+        assertThat(fU_a.le(fR2_b), is(equalTo(true)));
+        assertThat(fU_a.le(fL_a), is(equalTo(true)));
+        assertThat(fU_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fU_b.le(fU_a), is(equalTo(false)));
+        assertThat(fU_b.le(fU_b), is(equalTo(true)));
+        assertThat(fU_b.le(fR1_a), is(equalTo(true)));
+        assertThat(fU_b.le(fR1_b), is(equalTo(true)));
+        assertThat(fU_b.le(fR2_a), is(equalTo(true)));
+        assertThat(fU_b.le(fR2_b), is(equalTo(true)));
+        assertThat(fU_b.le(fL_a), is(equalTo(true)));
+        assertThat(fU_b.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR1_a.le(fU_a), is(equalTo(false)));
+        assertThat(fR1_a.le(fU_b), is(equalTo(false)));
+        assertThat(fR1_a.le(fR1_a), is(equalTo(true)));
+        assertThat(fR1_a.le(fR1_b), is(equalTo(true)));
+        assertThat(fR1_a.le(fR2_a), is(equalTo(false)));
+        assertThat(fR1_a.le(fR2_b), is(equalTo(false)));
+        assertThat(fR1_a.le(fL_a), is(equalTo(true)));
+        assertThat(fR1_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR1_b.le(fU_a), is(equalTo(false)));
+        assertThat(fR1_b.le(fU_b), is(equalTo(false)));
+        assertThat(fR1_b.le(fR1_a), is(equalTo(false)));
+        assertThat(fR1_b.le(fR1_b), is(equalTo(true)));
+        assertThat(fR1_b.le(fR2_a), is(equalTo(false)));
+        assertThat(fR1_b.le(fR2_b), is(equalTo(false)));
+        assertThat(fR1_b.le(fL_a), is(equalTo(true)));
+        assertThat(fR1_b.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR2_a.le(fU_a), is(equalTo(false)));
+        assertThat(fR2_a.le(fU_b), is(equalTo(false)));
+        assertThat(fR2_a.le(fR1_a), is(equalTo(false)));
+        assertThat(fR2_a.le(fR1_b), is(equalTo(false)));
+        assertThat(fR2_a.le(fR2_a), is(equalTo(true)));
+        assertThat(fR2_a.le(fR2_b), is(equalTo(true)));
+        assertThat(fR2_a.le(fL_a), is(equalTo(true)));
+        assertThat(fR2_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fR2_b.le(fU_a), is(equalTo(false)));
+        assertThat(fR2_b.le(fU_b), is(equalTo(false)));
+        assertThat(fR2_b.le(fR1_a), is(equalTo(false)));
+        assertThat(fR2_b.le(fR1_b), is(equalTo(false)));
+        assertThat(fR2_b.le(fR2_a), is(equalTo(false)));
+        assertThat(fR2_b.le(fR2_b), is(equalTo(true)));
+        assertThat(fR2_b.le(fL_a), is(equalTo(true)));
+        assertThat(fR2_b.le(fL_b), is(equalTo(true)));
+
+        assertThat(fL_a.le(fU_a), is(equalTo(false)));
+        assertThat(fL_a.le(fU_b), is(equalTo(false)));
+        assertThat(fL_a.le(fR1_a), is(equalTo(false)));
+        assertThat(fL_a.le(fR1_b), is(equalTo(false)));
+        assertThat(fL_a.le(fR2_a), is(equalTo(false)));
+        assertThat(fL_a.le(fR2_b), is(equalTo(false)));
+        assertThat(fL_a.le(fL_a), is(equalTo(true)));
+        assertThat(fL_a.le(fL_b), is(equalTo(true)));
+
+        assertThat(fL_b.le(fU_a), is(equalTo(false)));
+        assertThat(fL_b.le(fU_b), is(equalTo(false)));
+        assertThat(fL_b.le(fR1_a), is(equalTo(false)));
+        assertThat(fL_b.le(fR1_b), is(equalTo(false)));
+        assertThat(fL_b.le(fR2_a), is(equalTo(false)));
+        assertThat(fL_b.le(fR2_b), is(equalTo(false)));
+        assertThat(fL_b.le(fL_a), is(equalTo(false)));
+        assertThat(fL_b.le(fL_b), is(equalTo(true)));
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileInRevisionTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileInRevisionTest.java
@@ -200,4 +200,72 @@ public class FileInRevisionTest {
         assertThat(fL_b.le(fL_a), is(equalTo(false)));
         assertThat(fL_b.le(fL_b), is(equalTo(true)));
     }
+
+    @Test
+    public void testTopoSortOnTotalOrder() {
+        final IRevision u = ChangestructureFactory.createUnknownRevision(StubRepo.INSTANCE);
+        final IRevision r1 = ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(1), StubRepo.INSTANCE);
+        final IRevision r2 = ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2), StubRepo.INSTANCE);
+        final IRevision l = ChangestructureFactory.createLocalRevision(StubWorkingCopy.INSTANCE);
+
+        final IRevisionedFile fU_a = ChangestructureFactory.createFileInRevision("/a", u);
+        final IRevisionedFile fU_b = ChangestructureFactory.createFileInRevision("/b", u);
+        final IRevisionedFile fR1_a = ChangestructureFactory.createFileInRevision("/a", r1);
+        final IRevisionedFile fR1_b = ChangestructureFactory.createFileInRevision("/b", r1);
+        final IRevisionedFile fR2_a = ChangestructureFactory.createFileInRevision("/a", r2);
+        final IRevisionedFile fR2_b = ChangestructureFactory.createFileInRevision("/b", r2);
+        final IRevisionedFile fL_a = ChangestructureFactory.createFileInRevision("/a", l);
+        final IRevisionedFile fL_b = ChangestructureFactory.createFileInRevision("/b", l);
+
+        final List<IRevisionedFile> files = new ArrayList<>();
+        files.add(fL_b);
+        files.add(fL_a);
+        files.add(fR2_b);
+        files.add(fR2_a);
+        files.add(fR1_b);
+        files.add(fR1_a);
+        files.add(fU_b);
+        files.add(fU_a);
+
+        assertThat(PartialOrderAlgorithms.topoSort(files),
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR1_a, fR1_b, fR2_a, fR2_b, fL_a, fL_b))));
+    }
+
+    @Test
+    public void testTopoSortOnPartialOrder() {
+        final IRevision u = ChangestructureFactory.createUnknownRevision(PartiallyOrderedRepo.INSTANCE);
+        final IRevision r1 = ChangestructureFactory.createRepoRevision(new PartiallyOrderedID("abcd"),
+                PartiallyOrderedRepo.INSTANCE);
+        final IRevision r2 = ChangestructureFactory.createRepoRevision(new PartiallyOrderedID("efgh"),
+                PartiallyOrderedRepo.INSTANCE);
+        final IRevision l = ChangestructureFactory.createLocalRevision(PartiallyOrderedWorkingCopy.INSTANCE);
+
+        final IRevisionedFile fU_a = ChangestructureFactory.createFileInRevision("/a", u);
+        final IRevisionedFile fU_b = ChangestructureFactory.createFileInRevision("/b", u);
+        final IRevisionedFile fR1_a = ChangestructureFactory.createFileInRevision("/a", r1);
+        final IRevisionedFile fR1_b = ChangestructureFactory.createFileInRevision("/b", r1);
+        final IRevisionedFile fR2_a = ChangestructureFactory.createFileInRevision("/a", r2);
+        final IRevisionedFile fR2_b = ChangestructureFactory.createFileInRevision("/b", r2);
+        final IRevisionedFile fL_a = ChangestructureFactory.createFileInRevision("/a", l);
+        final IRevisionedFile fL_b = ChangestructureFactory.createFileInRevision("/b", l);
+
+        final List<IRevisionedFile> files = new ArrayList<>();
+        files.add(fL_b);
+        files.add(fL_a);
+        files.add(fR2_b);
+        files.add(fR2_a);
+        files.add(fR1_b);
+        files.add(fR1_a);
+        files.add(fU_b);
+        files.add(fU_a);
+
+        assertThat(PartialOrderAlgorithms.topoSort(files), anyOf(
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR1_a, fR1_b, fR2_a, fR2_b, fL_a, fL_b))),
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR1_a, fR2_a, fR1_b, fR2_b, fL_a, fL_b))),
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR1_a, fR2_a, fR2_b, fR1_b, fL_a, fL_b))),
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR2_a, fR2_b, fR1_a, fR1_b, fL_a, fL_b))),
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR2_a, fR1_a, fR2_b, fR1_b, fL_a, fL_b))),
+                is(equalTo(Arrays.asList(fU_a, fU_b, fR2_a, fR1_a, fR1_b, fR2_b, fL_a, fL_b)))
+        ));
+    }
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/HunkMergeTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IFileDiff;
 import de.setsoftware.reviewtool.model.api.IFragment;
 import de.setsoftware.reviewtool.model.api.IHunk;
@@ -18,10 +19,10 @@ import de.setsoftware.reviewtool.model.api.IncompatibleFragmentException;
 public class HunkMergeTest {
 
     private static FileInRevision file(final int revision) {
-        return new FileInRevision("file", new RepoRevision(revision, StubRepo.INSTANCE));
+        return new FileInRevision("file", new RepoRevision<>(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
-    private static PositionInText pos(int line, int col) {
+    private static PositionInText pos(final int line, final int col) {
         return new PositionInText(line, col);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PartiallyOrderedID.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PartiallyOrderedID.java
@@ -1,0 +1,30 @@
+package de.setsoftware.reviewtool.model.changestructure;
+
+import de.setsoftware.reviewtool.base.IPartiallyComparable;
+
+final class PartiallyOrderedID implements IPartiallyComparable<PartiallyOrderedID> {
+    private final String id;
+    PartiallyOrderedID(final String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean le(final PartiallyOrderedID other) {
+        return this.id.length() < other.id.length()
+                || this.id.equals(other.id);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof PartiallyOrderedID) {
+            final PartiallyOrderedID other = (PartiallyOrderedID) obj;
+            return this.id.equals(other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.id.hashCode();
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PartiallyOrderedRepo.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PartiallyOrderedRepo.java
@@ -2,17 +2,13 @@ package de.setsoftware.reviewtool.model.changestructure;
 
 import java.util.Collection;
 
-import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.api.IRevision;
 
-/**
- * A stub implementation of {@link AbstractRepository} for use by tests.
- */
-public final class StubRepo extends AbstractRepository {
+final class PartiallyOrderedRepo extends AbstractRepository {
 
-    public static StubRepo INSTANCE = new StubRepo();
+    public static PartiallyOrderedRepo INSTANCE = new PartiallyOrderedRepo();
     private static final long serialVersionUID = 1L;
 
     @Override
@@ -21,8 +17,8 @@ public final class StubRepo extends AbstractRepository {
     }
 
     @Override
-    public IRepoRevision<ComparableWrapper<Integer>> toRevision(final String revisionId) {
-        return ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(Integer.parseInt(revisionId)), this);
+    public IRepoRevision<PartiallyOrderedID> toRevision(final String revisionId) {
+        return ChangestructureFactory.createRepoRevision(new PartiallyOrderedID(revisionId), this);
     }
 
     @Override

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PartiallyOrderedWorkingCopy.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/PartiallyOrderedWorkingCopy.java
@@ -1,0 +1,36 @@
+package de.setsoftware.reviewtool.model.changestructure;
+
+import java.io.File;
+
+import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
+import de.setsoftware.reviewtool.model.api.IRepository;
+
+final class PartiallyOrderedWorkingCopy extends AbstractWorkingCopy {
+
+    public static PartiallyOrderedWorkingCopy INSTANCE = new PartiallyOrderedWorkingCopy();
+
+    @Override
+    public IRepository getRepository() {
+        return PartiallyOrderedRepo.INSTANCE;
+    }
+
+    @Override
+    public File getLocalRoot() {
+        return new File("/");
+    }
+
+    @Override
+    public String getRelativePath() {
+        return null;
+    }
+
+    @Override
+    public String toAbsolutePathInWc(final String absolutePathInRepo) {
+        return absolutePathInRepo;
+    }
+
+    @Override
+    public IMutableFileHistoryGraph getFileHistoryGraph() {
+        return null;
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/RevisionTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/RevisionTest.java
@@ -1,0 +1,72 @@
+package de.setsoftware.reviewtool.model.changestructure;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import de.setsoftware.reviewtool.base.ComparableWrapper;
+import de.setsoftware.reviewtool.model.api.IRevision;
+
+/**
+ * Tests revisions.
+ */
+public class RevisionTest {
+
+    @Test
+    public void testTotalOrder() {
+        final IRevision u = ChangestructureFactory.createUnknownRevision(StubRepo.INSTANCE);
+        final IRevision r1 = ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(1), StubRepo.INSTANCE);
+        final IRevision r2 = ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2), StubRepo.INSTANCE);
+        final IRevision l = ChangestructureFactory.createLocalRevision(StubWorkingCopy.INSTANCE);
+
+        assertThat(u.le(u), is(equalTo(true)));
+        assertThat(u.le(r1), is(equalTo(true)));
+        assertThat(u.le(r2), is(equalTo(true)));
+        assertThat(u.le(l), is(equalTo(true)));
+
+        assertThat(r1.le(u), is(equalTo(false)));
+        assertThat(r1.le(r1), is(equalTo(true)));
+        assertThat(r1.le(r2), is(equalTo(true)));
+        assertThat(r1.le(l), is(equalTo(true)));
+
+        assertThat(r2.le(u), is(equalTo(false)));
+        assertThat(r2.le(r1), is(equalTo(false)));
+        assertThat(r2.le(r2), is(equalTo(true)));
+        assertThat(r2.le(l), is(equalTo(true)));
+
+        assertThat(l.le(u), is(equalTo(false)));
+        assertThat(l.le(r1), is(equalTo(false)));
+        assertThat(l.le(r2), is(equalTo(false)));
+        assertThat(l.le(l), is(equalTo(true)));
+    }
+
+    @Test
+    public void testPartialOrder() {
+        final IRevision u = ChangestructureFactory.createUnknownRevision(PartiallyOrderedRepo.INSTANCE);
+        final IRevision r1 = ChangestructureFactory.createRepoRevision(new PartiallyOrderedID("abcd"), PartiallyOrderedRepo.INSTANCE);
+        final IRevision r2 = ChangestructureFactory.createRepoRevision(new PartiallyOrderedID("efgh"), PartiallyOrderedRepo.INSTANCE);
+        final IRevision l = ChangestructureFactory.createLocalRevision(PartiallyOrderedWorkingCopy.INSTANCE);
+
+        assertThat(u.le(u), is(equalTo(true)));
+        assertThat(u.le(r1), is(equalTo(true)));
+        assertThat(u.le(r2), is(equalTo(true)));
+        assertThat(u.le(l), is(equalTo(true)));
+
+        assertThat(r1.le(u), is(equalTo(false)));
+        assertThat(r1.le(r1), is(equalTo(true)));
+        assertThat(r1.le(r2), is(equalTo(false)));
+        assertThat(r1.le(l), is(equalTo(true)));
+
+        assertThat(r2.le(u), is(equalTo(false)));
+        assertThat(r2.le(r1), is(equalTo(false)));
+        assertThat(r2.le(r2), is(equalTo(true)));
+        assertThat(r2.le(l), is(equalTo(true)));
+
+        assertThat(l.le(u), is(equalTo(false)));
+        assertThat(l.le(r1), is(equalTo(false)));
+        assertThat(l.le(r2), is(equalTo(false)));
+        assertThat(l.le(l), is(equalTo(true)));
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/StopTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/StopTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IPositionInText;
 
 /**
@@ -14,11 +15,11 @@ import de.setsoftware.reviewtool.model.api.IPositionInText;
  */
 public class StopTest {
 
-    private static FileInRevision file(String name, int revision) {
-        return new FileInRevision(name, new RepoRevision(revision, StubRepo.INSTANCE));
+    private static FileInRevision file(final String name, final int revision) {
+        return new FileInRevision(name, new RepoRevision<>(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
-    private static IPositionInText line(int line) {
+    private static IPositionInText line(final int line) {
         return ChangestructureFactory.createPositionInText(line, 1);
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TestFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TestFileHistoryGraph.java
@@ -2,6 +2,7 @@ package de.setsoftware.reviewtool.model.changestructure;
 
 import java.util.List;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.diffalgorithms.DiffAlgorithmFactory;
 import de.setsoftware.reviewtool.model.api.IFileHistoryGraph;
 import de.setsoftware.reviewtool.model.api.IFileHistoryNode;
@@ -60,8 +61,8 @@ final class TestFileHistoryGraph extends FileHistoryGraph {
             }
 
             @Override
-            public Long handleRepoRevision(final IRepoRevision revision) {
-                return (Long) revision.getId();
+            public Long handleRepoRevision(final IRepoRevision<?> revision) {
+                return ComparableWrapper.<Long> unwrap(revision.getId());
             }
 
             @Override

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TestRepoRevision.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TestRepoRevision.java
@@ -1,62 +1,66 @@
 package de.setsoftware.reviewtool.model.changestructure;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.api.IRepository;
+import de.setsoftware.reviewtool.model.api.IRevision;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitor;
 import de.setsoftware.reviewtool.model.api.IRevisionVisitorE;
 
 /**
  * Implements {@link IRepoRevision} for this test case.
  */
-final class TestRepoRevision implements IRepoRevision {
+final class TestRepoRevision implements IRepoRevision<ComparableWrapper<Long>> {
 
     private static final long serialVersionUID = 1L;
 
-    private final IRepository repo;
-    private final Long id;
+    private final RepoRevision<ComparableWrapper<Long>> revision;
 
     TestRepoRevision(final IRepository repo, final Long id) {
-        this.repo = repo;
-        this.id = id;
+        this.revision = new RepoRevision<>(ComparableWrapper.wrap(id), repo);
     }
 
     @Override
     public IRepository getRepository() {
-        return this.repo;
+        return this.revision.getRepository();
     }
 
     @Override
     public <R> R accept(final IRevisionVisitor<R> visitor) {
-        return visitor.handleRepoRevision(this);
+        return this.revision.accept(visitor);
     }
 
     @Override
     public <R, E extends Throwable> R accept(final IRevisionVisitorE<R, E> visitor) throws E {
-        return visitor.handleRepoRevision(this);
+        return this.revision.accept(visitor);
     }
 
     @Override
-    public Object getId() {
-        return this.id;
+    public ComparableWrapper<Long> getId() {
+        return this.revision.getId();
+    }
+
+    @Override
+    public boolean le(final IRevision other) {
+        return this.revision.le(other);
     }
 
     @Override
     public boolean equals(final Object o) {
         if (o instanceof TestRepoRevision) {
             final TestRepoRevision other = (TestRepoRevision) o;
-            return this.id.equals(other.id);
+            return this.revision.equals(other.revision);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return this.id.hashCode();
+        return this.revision.hashCode();
     }
 
     @Override
     public String toString() {
-        return this.id.toString();
+        return this.revision.toString();
     }
-
 }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TestRepository.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TestRepository.java
@@ -2,6 +2,7 @@ package de.setsoftware.reviewtool.model.changestructure;
 
 import java.util.Collection;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
 import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.api.IRepository;
@@ -26,7 +27,7 @@ final class TestRepository extends AbstractRepository {
     }
 
     @Override
-    public IRepoRevision toRevision(final String revisionId) {
+    public IRepoRevision<ComparableWrapper<Long>> toRevision(final String revisionId) {
         try {
             return new TestRepoRevision(this, Long.parseLong(revisionId));
         } catch (final NumberFormatException e) {
@@ -40,7 +41,7 @@ final class TestRepository extends AbstractRepository {
     }
 
     @Override
-    public byte[] getFileContents(final String path, final IRepoRevision revision) throws Exception {
+    public byte[] getFileContents(final String path, final IRepoRevision<?> revision) {
         return new byte[0];
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TourTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/TourTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IFragment;
 
 /**
@@ -12,12 +13,12 @@ import de.setsoftware.reviewtool.model.api.IFragment;
  */
 public class TourTest {
 
-    private static PositionInText pos(int line, int column) {
+    private static PositionInText pos(final int line, final int column) {
         return new PositionInText(line, column);
     }
 
-    private static FileInRevision file(String name, int revision) {
-        return new FileInRevision(name, new RepoRevision(revision, StubRepo.INSTANCE));
+    private static FileInRevision file(final String name, final int revision) {
+        return new FileInRevision(name, new RepoRevision<>(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
     @Test

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
@@ -1,0 +1,594 @@
+package de.setsoftware.reviewtool.model.changestructure;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.setsoftware.reviewtool.base.ComparableWrapper;
+import de.setsoftware.reviewtool.model.api.IFileHistoryEdge;
+import de.setsoftware.reviewtool.model.api.IFileHistoryNode;
+import de.setsoftware.reviewtool.model.api.ILocalRevision;
+import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
+import de.setsoftware.reviewtool.model.api.IRepoRevision;
+import de.setsoftware.reviewtool.model.api.IRevision;
+import de.setsoftware.reviewtool.model.api.IRevisionedFile;
+
+/**
+ * Tests {@link VirtualFileHistoryGraph}.
+ */
+public class VirtualFileHistoryGraphTest {
+
+    private TestRepository repo;
+    private TestWorkingCopy wc;
+    private IMutableFileHistoryGraph remoteFileHistoryGraph;
+    private VirtualFileHistoryGraph virtualFileHistoryGraph;
+
+    private IRepoRevision<ComparableWrapper<Long>> rev(final long id) {
+        return new TestRepoRevision(this.repo, id);
+    }
+
+    private ILocalRevision localRev() {
+        return ChangestructureFactory.createLocalRevision(this.wc);
+    }
+
+    private IRevisionedFile file(final String path, final IRevision revision) {
+        return ChangestructureFactory.createFileInRevision(path, revision);
+    }
+
+    private boolean hasOnlyAlphaAncestor(final IFileHistoryNode node) {
+        final Set<? extends IFileHistoryEdge> ancestors = node.getAncestors();
+        if (ancestors.size() != 1) {
+            return false;
+        } else {
+            return ancestors.iterator().next().getAncestor().getFile().getRevision().equals(
+                    ChangestructureFactory.createUnknownRevision(this.repo));
+        }
+    }
+
+    @Before
+    public void setUp() {
+        this.repo = new TestRepository("/some/repo");
+        this.wc = new TestWorkingCopy(this.repo, new File("/some/wc"));
+        this.remoteFileHistoryGraph = new TestFileHistoryGraph();
+        this.virtualFileHistoryGraph = new VirtualFileHistoryGraph(this.remoteFileHistoryGraph);
+        // revision 1
+        this.remoteFileHistoryGraph.addAddition("/dir1", rev(1));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2", rev(1));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2/a.txt", rev(1));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2/b.txt", rev(1));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2/c.txt", rev(1));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2/d.txt", rev(1));
+        // revision 2
+        this.remoteFileHistoryGraph.addChange("/dir1/dir2/a.txt", rev(2), Collections.singleton(rev(1)));
+        this.remoteFileHistoryGraph.addDeletion("/dir1/dir2/b.txt", rev(2));
+        this.remoteFileHistoryGraph.addReplacement("/dir1/dir2/c.txt", rev(2));
+    }
+
+    @Test
+    public void testNoLocalChanges() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        this.testThatAIsUnchanged();
+        this.testThatBIsUnchanged();
+        this.testThatCIsUnchanged();
+        this.testThatDIsUnchanged();
+    }
+
+    private void testThatAIsUnchanged() {
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode aNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", localRev()));
+        assertThat(aNodeL, is(nullValue()));
+
+        assertThat(aNodeR2.getDescendants().isEmpty(), is(equalTo(true)));
+    }
+
+    private void testThatBIsUnchanged() {
+        final IFileHistoryNode bNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/b.txt", rev(2)));
+        assertThat(bNodeR2, is(not(nullValue())));
+        assertThat(bNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.DELETED)));
+        final IFileHistoryNode bNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/b.txt", localRev()));
+        assertThat(bNodeL, is(nullValue()));
+
+        assertThat(bNodeR2.getDescendants().isEmpty(), is(equalTo(true)));
+    }
+
+    private void testThatCIsUnchanged() {
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(nullValue()));
+
+        assertThat(cNodeR2.getDescendants().isEmpty(), is(equalTo(true)));
+    }
+
+    private void testThatDIsUnchanged() {
+        final IFileHistoryNode dNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(1)));
+        assertThat(dNodeR1, is(not(nullValue())));
+        assertThat(dNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode dNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(2)));
+        assertThat(dNodeR2, is(nullValue()));
+        final IFileHistoryNode dNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", localRev()));
+        assertThat(dNodeL, is(nullValue()));
+
+        assertThat(dNodeR1.getDescendants().isEmpty(), is(equalTo(true)));
+    }
+
+    @Test
+    public void testLocalAddition() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addAddition("/dir1/dir2/b.txt", localRev());
+        localGraph.addAddition("/dir1/dir2/e.txt", localRev());
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        this.testThatAIsUnchanged();
+
+        final IFileHistoryNode bNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/b.txt", rev(2)));
+        assertThat(bNodeR2, is(not(nullValue())));
+        assertThat(bNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.DELETED)));
+        final IFileHistoryNode bNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/b.txt", localRev()));
+        assertThat(bNodeL, is(not(nullValue())));
+        assertThat(bNodeL.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+
+        assertThat(bNodeR2.getDescendants().isEmpty(), is(equalTo(true)));
+        assertThat(hasOnlyAlphaAncestor(bNodeL), is(equalTo(true)));
+
+        this.testThatCIsUnchanged();
+        this.testThatDIsUnchanged();
+
+        final IFileHistoryNode eNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/e.txt", rev(2)));
+        assertThat(eNodeR2, is(nullValue()));
+        final IFileHistoryNode eNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/e.txt", localRev()));
+        assertThat(eNodeL, is(not(nullValue())));
+        assertThat(eNodeL.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+
+        assertThat(hasOnlyAlphaAncestor(eNodeL), is(equalTo(true)));
+    }
+
+    @Test
+    public void testLocalChangeInSameRevision() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addChange("/dir1/dir2/a.txt", localRev(), Collections.singleton(rev(2)));
+        localGraph.addChange("/dir1/dir2/c.txt", localRev(), Collections.singleton(rev(2)));
+        localGraph.addChange("/dir1/dir2/d.txt", localRev(), Collections.singleton(rev(2)));
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode aNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", localRev()));
+        assertThat(aNodeL, is(not(nullValue())));
+        assertThat(aNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge aEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR2,
+                aNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR2.getFile(), aNodeL.getFile()));
+        assertThat(aNodeR2.getDescendants(), is(equalTo(Collections.singleton(aEdgeR2L))));
+        assertThat(aNodeL.getAncestors(), is(equalTo(Collections.singleton(aEdgeR2L))));
+
+        this.testThatBIsUnchanged();
+
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(not(nullValue())));
+        assertThat(cNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge cEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR2,
+                cNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR2.getFile(), cNodeL.getFile()));
+        assertThat(cNodeR2.getDescendants(), is(equalTo(Collections.singleton(cEdgeR2L))));
+        assertThat(cNodeL.getAncestors(), is(equalTo(Collections.singleton(cEdgeR2L))));
+
+        final IFileHistoryNode dNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(1)));
+        assertThat(dNodeR1, is(not(nullValue())));
+        assertThat(dNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode dNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(2)));
+        assertThat(dNodeR2, is(not(nullValue())));
+        assertThat(dNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.UNCONFIRMED)));
+        final IFileHistoryNode dNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", localRev()));
+        assertThat(dNodeL, is(not(nullValue())));
+        assertThat(dNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge dEdgeR1R2 = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                dNodeR1,
+                dNodeR2,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(dNodeR1.getFile(), dNodeR2.getFile()));
+        final IFileHistoryEdge dEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                dNodeR2,
+                dNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(dNodeR2.getFile(), dNodeL.getFile()));
+        assertThat(dNodeR1.getDescendants(), is(equalTo(Collections.singleton(dEdgeR1R2))));
+        assertThat(dNodeR2.getAncestors(), is(equalTo(Collections.singleton(dEdgeR1R2))));
+        assertThat(dNodeR2.getDescendants(), is(equalTo(Collections.singleton(dEdgeR2L))));
+        assertThat(dNodeL.getAncestors(), is(equalTo(Collections.singleton(dEdgeR2L))));
+    }
+
+    @Test
+    public void testLocalChangeInLaterRevision() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addChange("/dir1/dir2/a.txt", localRev(), Collections.singleton(rev(3)));
+        localGraph.addChange("/dir1/dir2/c.txt", localRev(), Collections.singleton(rev(3)));
+        localGraph.addChange("/dir1/dir2/d.txt", localRev(), Collections.singleton(rev(3)));
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode aNodeR3 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(3)));
+        assertThat(aNodeR3, is(not(nullValue())));
+        assertThat(aNodeR3.getType(), is(equalTo(IFileHistoryNode.Type.UNCONFIRMED)));
+        final IFileHistoryNode aNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", localRev()));
+        assertThat(aNodeL, is(not(nullValue())));
+        assertThat(aNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge aEdgeR2R3 = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR2,
+                aNodeR3,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR2.getFile(), aNodeR3.getFile()));
+        assertThat(aNodeR2.getDescendants(), is(equalTo(Collections.singleton(aEdgeR2R3))));
+        assertThat(aNodeR3.getAncestors(), is(equalTo(Collections.singleton(aEdgeR2R3))));
+        final IFileHistoryEdge aEdgeR3L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR3,
+                aNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR3.getFile(), aNodeL.getFile()));
+        assertThat(aNodeR3.getDescendants(), is(equalTo(Collections.singleton(aEdgeR3L))));
+        assertThat(aNodeL.getAncestors(), is(equalTo(Collections.singleton(aEdgeR3L))));
+
+        this.testThatBIsUnchanged();
+
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeR3 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(3)));
+        assertThat(cNodeR3, is(not(nullValue())));
+        assertThat(cNodeR3.getType(), is(equalTo(IFileHistoryNode.Type.UNCONFIRMED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(not(nullValue())));
+        assertThat(cNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge cEdgeR2R3 = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR2,
+                cNodeR3,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR2.getFile(), cNodeR3.getFile()));
+        assertThat(cNodeR2.getDescendants(), is(equalTo(Collections.singleton(cEdgeR2R3))));
+        assertThat(cNodeR3.getAncestors(), is(equalTo(Collections.singleton(cEdgeR2R3))));
+        final IFileHistoryEdge cEdgeR3L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR3,
+                cNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR3.getFile(), cNodeL.getFile()));
+        assertThat(cNodeR3.getDescendants(), is(equalTo(Collections.singleton(cEdgeR3L))));
+        assertThat(cNodeL.getAncestors(), is(equalTo(Collections.singleton(cEdgeR3L))));
+
+        final IFileHistoryNode dNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(1)));
+        assertThat(dNodeR1, is(not(nullValue())));
+        assertThat(dNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode dNodeR3 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(3)));
+        assertThat(dNodeR3, is(not(nullValue())));
+        assertThat(dNodeR3.getType(), is(equalTo(IFileHistoryNode.Type.UNCONFIRMED)));
+        final IFileHistoryNode dNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", localRev()));
+        assertThat(dNodeL, is(not(nullValue())));
+        assertThat(dNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge dEdgeR1R3 = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                dNodeR1,
+                dNodeR3,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(dNodeR1.getFile(), dNodeR3.getFile()));
+        assertThat(dNodeR1.getDescendants(), is(equalTo(Collections.singleton(dEdgeR1R3))));
+        assertThat(dNodeR3.getAncestors(), is(equalTo(Collections.singleton(dEdgeR1R3))));
+        final IFileHistoryEdge dEdgeR3L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                dNodeR3,
+                dNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(dNodeR3.getFile(), dNodeL.getFile()));
+        assertThat(dNodeR3.getDescendants(), is(equalTo(Collections.singleton(dEdgeR3L))));
+        assertThat(dNodeL.getAncestors(), is(equalTo(Collections.singleton(dEdgeR3L))));
+    }
+
+    @Test
+    public void testLocalDeletion() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addDeletion("/dir1/dir2/a.txt", localRev());
+        localGraph.addDeletion("/dir1/dir2/c.txt", localRev());
+        localGraph.addDeletion("/dir1/dir2/d.txt", localRev());
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode aNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", localRev()));
+        assertThat(aNodeL, is(not(nullValue())));
+        assertThat(aNodeL.getType(), is(equalTo(IFileHistoryNode.Type.DELETED)));
+
+        final IFileHistoryEdge aEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR2,
+                aNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR2.getFile(), aNodeL.getFile()));
+        assertThat(aNodeR2.getDescendants(), is(equalTo(Collections.singleton(aEdgeR2L))));
+        assertThat(aNodeL.getAncestors(), is(equalTo(Collections.singleton(aEdgeR2L))));
+
+        this.testThatBIsUnchanged();
+
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(not(nullValue())));
+        assertThat(cNodeL.getType(), is(equalTo(IFileHistoryNode.Type.DELETED)));
+
+        final IFileHistoryEdge cEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR2,
+                cNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR2.getFile(), cNodeL.getFile()));
+        assertThat(cNodeR2.getDescendants(), is(equalTo(Collections.singleton(cEdgeR2L))));
+        assertThat(cNodeL.getAncestors(), is(equalTo(Collections.singleton(cEdgeR2L))));
+
+        final IFileHistoryNode dNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(1)));
+        assertThat(dNodeR1, is(not(nullValue())));
+        assertThat(dNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode dNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", localRev()));
+        assertThat(dNodeL, is(not(nullValue())));
+        assertThat(dNodeL.getType(), is(equalTo(IFileHistoryNode.Type.DELETED)));
+
+        final IFileHistoryEdge dEdgeR1L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                dNodeR1,
+                dNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(dNodeR1.getFile(), dNodeL.getFile()));
+        assertThat(dNodeR1.getDescendants(), is(equalTo(Collections.singleton(dEdgeR1L))));
+        assertThat(dNodeL.getAncestors(), is(equalTo(Collections.singleton(dEdgeR1L))));
+    }
+
+    @Test
+    public void testLocalCopyOfLatestRevision() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/e.txt", rev(2), localRev());
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode eNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/e.txt", localRev()));
+        assertThat(eNodeL, is(not(nullValue())));
+        assertThat(eNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge aEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR2,
+                eNodeL,
+                IFileHistoryEdge.Type.COPY,
+                new FileDiff(aNodeR2.getFile(), eNodeL.getFile()));
+        assertThat(aNodeR2.getDescendants(), is(equalTo(Collections.singleton(aEdgeR2L))));
+        assertThat(eNodeL.getAncestors(), is(equalTo(Collections.singleton(aEdgeR2L))));
+
+        this.testThatBIsUnchanged();
+        this.testThatCIsUnchanged();
+        this.testThatDIsUnchanged();
+    }
+
+    @Test
+    public void testLocalCopyOfOlderRevision() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/e.txt", rev(1), localRev());
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(1)));
+        assertThat(aNodeR1, is(not(nullValue())));
+        assertThat(aNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode eNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/e.txt", localRev()));
+        assertThat(eNodeL, is(not(nullValue())));
+        assertThat(eNodeL.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+
+        final IFileHistoryEdge aEdgeR1R2 = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR1,
+                aNodeR2,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR1.getFile(), aNodeR2.getFile()));
+        final IFileHistoryEdge aEdgeR1L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR1,
+                eNodeL,
+                IFileHistoryEdge.Type.COPY,
+                new FileDiff(aNodeR1.getFile(), eNodeL.getFile()));
+        assertThat(aNodeR1.getDescendants(), is(equalTo(
+                new HashSet<>(Arrays.asList(aEdgeR1R2, aEdgeR1L)))));
+        assertThat(aNodeR2.getAncestors(), is(equalTo(Collections.singleton(aEdgeR1R2))));
+        assertThat(aNodeR2.getDescendants().isEmpty(), is(equalTo(true)));
+        assertThat(eNodeL.getAncestors(), is(equalTo(Collections.singleton(aEdgeR1L))));
+
+        this.testThatBIsUnchanged();
+        this.testThatCIsUnchanged();
+        this.testThatDIsUnchanged();
+    }
+
+    @Test
+    public void testLocalReplacement() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addReplacement("/dir1/dir2/a.txt", localRev());
+        localGraph.addReplacement("/dir1/dir2/c.txt", localRev());
+        localGraph.addReplacement("/dir1/dir2/d.txt", localRev());
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode aNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", localRev()));
+        assertThat(aNodeL, is(not(nullValue())));
+        assertThat(aNodeL.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+
+        final IFileHistoryEdge aEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR2,
+                aNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR2.getFile(), aNodeL.getFile()));
+        assertThat(aNodeR2.getDescendants(), is(equalTo(Collections.singleton(aEdgeR2L))));
+        assertThat(aNodeL.getAncestors(), is(equalTo(Collections.singleton(aEdgeR2L))));
+
+        this.testThatBIsUnchanged();
+
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(not(nullValue())));
+        assertThat(cNodeL.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+
+        final IFileHistoryEdge cEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR2,
+                cNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR2.getFile(), cNodeL.getFile()));
+        assertThat(cNodeR2.getDescendants(), is(equalTo(Collections.singleton(cEdgeR2L))));
+        assertThat(cNodeL.getAncestors(), is(equalTo(Collections.singleton(cEdgeR2L))));
+
+        final IFileHistoryNode dNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", rev(1)));
+        assertThat(dNodeR1, is(not(nullValue())));
+        assertThat(dNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode dNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/d.txt", localRev()));
+        assertThat(dNodeL, is(not(nullValue())));
+        assertThat(dNodeL.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+
+        final IFileHistoryEdge dEdgeR1L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                dNodeR1,
+                dNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(dNodeR1.getFile(), dNodeL.getFile()));
+        assertThat(dNodeR1.getDescendants(), is(equalTo(Collections.singleton(dEdgeR1L))));
+        assertThat(dNodeL.getAncestors(), is(equalTo(Collections.singleton(dEdgeR1L))));
+    }
+
+    @Test
+    public void testLocalReplacementByCopyOfLatestRevision() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addReplacement("/dir1/dir2/c.txt", localRev(), "/dir1/dir2/a.txt", rev(2));
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(not(nullValue())));
+        assertThat(cNodeL.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+
+        final IFileHistoryEdge aEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR2,
+                cNodeL,
+                IFileHistoryEdge.Type.COPY,
+                new FileDiff(aNodeR2.getFile(), cNodeL.getFile()));
+        final IFileHistoryEdge cEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR2,
+                cNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR2.getFile(), cNodeL.getFile()));
+        assertThat(aNodeR2.getDescendants(), is(equalTo(Collections.singleton(aEdgeR2L))));
+        assertThat(cNodeR2.getDescendants(), is(equalTo(Collections.singleton(cEdgeR2L))));
+        assertThat(cNodeL.getAncestors(), is(equalTo(
+                new HashSet<>(Arrays.asList(cEdgeR2L, aEdgeR2L)))));
+
+        this.testThatBIsUnchanged();
+        this.testThatDIsUnchanged();
+    }
+
+    @Test
+    public void testLocalReplacementByCopyOfOlderRevision() {
+        final IMutableFileHistoryGraph localGraph = new TestFileHistoryGraph();
+        localGraph.addReplacement("/dir1/dir2/c.txt", localRev(), "/dir1/dir2/a.txt", rev(1));
+        this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
+
+        final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(1)));
+        assertThat(aNodeR1, is(not(nullValue())));
+        assertThat(aNodeR1.getType(), is(equalTo(IFileHistoryNode.Type.ADDED)));
+        final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/a.txt", rev(2)));
+        assertThat(aNodeR2, is(not(nullValue())));
+        assertThat(aNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.CHANGED)));
+        final IFileHistoryNode cNodeR2 = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", rev(2)));
+        assertThat(cNodeR2, is(not(nullValue())));
+        assertThat(cNodeR2.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+        final IFileHistoryNode cNodeL = this.virtualFileHistoryGraph.getNodeFor(file("/dir1/dir2/c.txt", localRev()));
+        assertThat(cNodeL, is(not(nullValue())));
+        assertThat(cNodeL.getType(), is(equalTo(IFileHistoryNode.Type.REPLACED)));
+
+        final IFileHistoryEdge aEdgeR1R2 = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR1,
+                aNodeR2,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(aNodeR1.getFile(), aNodeR2.getFile()));
+        final IFileHistoryEdge aEdgeR1L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                aNodeR1,
+                cNodeL,
+                IFileHistoryEdge.Type.COPY,
+                new FileDiff(aNodeR1.getFile(), cNodeL.getFile()));
+        final IFileHistoryEdge cEdgeR2L = new VirtualFileHistoryEdge(
+                this.virtualFileHistoryGraph,
+                cNodeR2,
+                cNodeL,
+                IFileHistoryEdge.Type.NORMAL,
+                new FileDiff(cNodeR2.getFile(), cNodeL.getFile()));
+
+        assertThat(aNodeR1.getDescendants(), is(equalTo(
+                new HashSet<>(Arrays.asList(aEdgeR1R2, aEdgeR1L)))));
+        assertThat(aNodeR2.getAncestors(), is(equalTo(Collections.singleton(aEdgeR1R2))));
+        assertThat(aNodeR2.getDescendants().isEmpty(), is(equalTo(true)));
+        assertThat(cNodeR2.getDescendants(), is(equalTo(Collections.singleton(cEdgeR2L))));
+        assertThat(cNodeL.getAncestors(), is(equalTo(
+                new HashSet<>(Arrays.asList(cEdgeR2L, aEdgeR1L)))));
+
+        this.testThatBIsUnchanged();
+        this.testThatDIsUnchanged();
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/ChangePartTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/ChangePartTest.java
@@ -9,6 +9,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IPositionInText;
 import de.setsoftware.reviewtool.model.api.IRepository;
 import de.setsoftware.reviewtool.model.api.IRevision;
@@ -23,13 +24,13 @@ import de.setsoftware.reviewtool.model.changestructure.StubRepo;
  */
 public class ChangePartTest {
 
-    private static ChangePart cp(Stop... stops) {
+    private static ChangePart cp(final Stop... stops) {
         return new ChangePart(Arrays.asList(stops));
     }
 
-    private static IRevisionedFile file(String name, int revision) {
+    private static IRevisionedFile file(final String name, final int revision) {
         return ChangestructureFactory.createFileInRevision(
-                name, ChangestructureFactory.createRepoRevision(revision, StubRepo.INSTANCE));
+                name, ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
     private static IRevisionedFile file(
@@ -45,7 +46,7 @@ public class ChangePartTest {
 
             @Override
             public IRevision getRevision() {
-                return ChangestructureFactory.createRepoRevision(revision, StubRepo.INSTANCE);
+                return ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), StubRepo.INSTANCE);
             }
 
             @Override
@@ -70,13 +71,13 @@ public class ChangePartTest {
         };
     }
 
-    private static Stop binaryStop(String filename) {
+    private static Stop binaryStop(final String filename) {
         return new Stop(
                 ChangestructureFactory.createBinaryChange(null, file(filename, 1), file(filename, 3), false),
                 file(filename, 4));
     }
 
-    private static Stop singleLineStop(IRevisionedFile file, int lineNumber) {
+    private static Stop singleLineStop(final IRevisionedFile file, final int lineNumber) {
         final IPositionInText posFrom = ChangestructureFactory.createPositionInText(lineNumber, 1);
         final IPositionInText posTo = ChangestructureFactory.createPositionInText(lineNumber + 1, 1);
         return new Stop(

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/ChangePartTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/ChangePartTest.java
@@ -38,25 +38,28 @@ public class ChangePartTest {
         return new IRevisionedFile() {
 
             private static final long serialVersionUID = 1L;
+            private final IRevisionedFile file = ChangestructureFactory.createFileInRevision(
+                    name,
+                    ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
 
             @Override
             public IPath toLocalPath(final IWorkingCopy wc) {
-                throw new UnsupportedOperationException();
+                return this.file.toLocalPath(wc);
             }
 
             @Override
             public IRevision getRevision() {
-                return ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), StubRepo.INSTANCE);
+                return this.file.getRevision();
             }
 
             @Override
             public IRepository getRepository() {
-                throw new UnsupportedOperationException();
+                return this.file.getRepository();
             }
 
             @Override
             public String getPath() {
-                return name;
+                return this.file.getPath();
             }
 
             @Override
@@ -66,7 +69,12 @@ public class ChangePartTest {
 
             @Override
             public IResource determineResource() {
-                throw new UnsupportedOperationException();
+                return this.file.determineResource();
+            }
+
+            @Override
+            public boolean le(final IRevisionedFile other) {
+                return this.file.le(other);
             }
         };
     }

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/TokenSimilarityRelationTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/TokenSimilarityRelationTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IFragment;
 import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 import de.setsoftware.reviewtool.model.changestructure.ChangestructureFactory;
@@ -22,18 +23,18 @@ import de.setsoftware.reviewtool.model.changestructure.StubRepo;
  */
 public class TokenSimilarityRelationTest {
 
-    private static IRevisionedFile file(String name, int revision) {
+    private static IRevisionedFile file(final String name, final int revision) {
         return ChangestructureFactory.createFileInRevision(
-                name, ChangestructureFactory.createRepoRevision(revision, StubRepo.INSTANCE));
+                name, ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
-    private static Stop binaryStop(String filename) {
+    private static Stop binaryStop(final String filename) {
         return new Stop(
                 ChangestructureFactory.createBinaryChange(null, file(filename, 1), file(filename, 3), false),
                 file(filename, 4));
     }
 
-    private static Stop stop(String commonPrefix, String oldContent, String newContent, String commonSuffix) {
+    private static Stop stop(final String commonPrefix, final String oldContent, final String newContent, final String commonSuffix) {
         final IFragment from = Fragment.createWithContent(file("test.java", 1),
                 ChangestructureFactory.createPositionInText(1, 1 + commonPrefix.length()),
                 ChangestructureFactory.createPositionInText(1, 1 + commonPrefix.length() + oldContent.length()),
@@ -47,15 +48,15 @@ public class TokenSimilarityRelationTest {
                 to);
     }
 
-    private static OrderingInfo oi(Stop s1, Stop s2) {
+    private static OrderingInfo oi(final Stop s1, final Stop s2) {
         return new SimpleUnorderedMatch(HierarchyExplicitness.NONE, null, Arrays.asList(wrap(s1), wrap(s2)));
     }
 
-    private static ChangePart wrap(Stop s) {
+    private static ChangePart wrap(final Stop s) {
         return new ChangePart(Collections.singletonList(s));
     }
 
-    private static List<ChangePart> wrap(Stop[] stops) {
+    private static List<ChangePart> wrap(final Stop[] stops) {
         final List<ChangePart> ret = new ArrayList<>();
         for (final Stop s : stops) {
             ret.add(wrap(s));
@@ -63,7 +64,7 @@ public class TokenSimilarityRelationTest {
         return ret;
     }
 
-    private static Collection<? extends OrderingInfo> determineRelations(Stop... stops) {
+    private static Collection<? extends OrderingInfo> determineRelations(final Stop... stops) {
         return new TokenSimilarityRelation().determineMatches(wrap(stops));
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/TourHierarchyBuilderTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/ordering/TourHierarchyBuilderTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 import de.setsoftware.reviewtool.model.changestructure.ChangestructureFactory;
 import de.setsoftware.reviewtool.model.changestructure.Stop;
@@ -24,30 +25,30 @@ import de.setsoftware.reviewtool.ordering.efficientalgorithm.PositionRequest;
  */
 public class TourHierarchyBuilderTest {
 
-    private static IRevisionedFile file(String name, int revision) {
+    private static IRevisionedFile file(final String name, final int revision) {
         return ChangestructureFactory.createFileInRevision(
-                name, ChangestructureFactory.createRepoRevision(revision, StubRepo.INSTANCE));
+                name, ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(revision), StubRepo.INSTANCE));
     }
 
-    private static Stop stop(String s) {
+    private static Stop stop(final String s) {
         return new Stop(
                 ChangestructureFactory.createBinaryChange(null, file(s, 1), file(s, 3), false),
                 file(s, 4));
     }
 
-    private static Tour tour(String description, TourElement... elements) {
+    private static Tour tour(final String description, final TourElement... elements) {
         return new Tour(description, Arrays.asList(elements));
     }
 
-    private static TourHierarchyBuilder builder(Stop... stops) {
+    private static TourHierarchyBuilder builder(final Stop... stops) {
         return new TourHierarchyBuilder(wrap(stops));
     }
 
-    private static ChangePart cp(Stop... stops) {
+    private static ChangePart cp(final Stop... stops) {
         return new ChangePart(Arrays.asList(stops));
     }
 
-    private static List<ChangePart> wrap(Stop... stops) {
+    private static List<ChangePart> wrap(final Stop... stops) {
         final List<ChangePart> changeParts = new ArrayList<>();
         for (final Stop s : stops) {
             changeParts.add(cp(s));
@@ -73,7 +74,7 @@ public class TourHierarchyBuilderTest {
 
             @Override
             public MatchSet<ChangePart> getMatchSet() {
-                return new MatchSet<ChangePart>(changeParts);
+                return new MatchSet<>(changeParts);
             }
 
             @Override

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/tourrestructuring/onestop/OneStopPerPartOfFileRestructuringTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/tourrestructuring/onestop/OneStopPerPartOfFileRestructuringTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.setsoftware.reviewtool.base.ComparableWrapper;
 import de.setsoftware.reviewtool.model.api.IPositionInText;
 import de.setsoftware.reviewtool.model.api.IRevisionedFile;
 import de.setsoftware.reviewtool.model.changestructure.ChangestructureFactory;
@@ -22,13 +23,13 @@ import de.setsoftware.reviewtool.model.changestructure.Tour;
  */
 public class OneStopPerPartOfFileRestructuringTest {
 
-    private static IRevisionedFile fileInRevision(String file, int i) {
+    private static IRevisionedFile fileInRevision(final String file, final int i) {
         return ChangestructureFactory.createFileInRevision(
                 file,
-                ChangestructureFactory.createRepoRevision(i, StubRepo.INSTANCE));
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(i), StubRepo.INSTANCE));
     }
 
-    private static Stop stop(final String file, int revision) {
+    private static Stop stop(final String file, final int revision) {
         return new Stop(
                 ChangestructureFactory.createBinaryChange(
                         null,
@@ -36,7 +37,7 @@ public class OneStopPerPartOfFileRestructuringTest {
                 fileInRevision(file, 100));
     }
 
-    private static Stop stop(final String file, int... revisions) {
+    private static Stop stop(final String file, final int... revisions) {
         Stop s = stop(file, revisions[0]);
         for (int i = 1; i < revisions.length; i++) {
             s = s.merge(stop(file, revisions[i]));
@@ -44,7 +45,7 @@ public class OneStopPerPartOfFileRestructuringTest {
         return s;
     }
 
-    private static Stop stopWithLines(final String file, int revision, int lineFrom, int lineTo) {
+    private static Stop stopWithLines(final String file, final int revision, final int lineFrom, final int lineTo) {
         final IPositionInText posFrom = ChangestructureFactory.createPositionInText(lineFrom, 1);
         final IPositionInText posTo = ChangestructureFactory.createPositionInText(lineTo + 1, 1);
         return new Stop(
@@ -56,7 +57,7 @@ public class OneStopPerPartOfFileRestructuringTest {
                 ChangestructureFactory.createFragment(fileInRevision(file, 100), posFrom, posTo));
     }
 
-    private static Tour tour(String description, int revision, String... filesWithStops) {
+    private static Tour tour(final String description, final int revision, final String... filesWithStops) {
         final List<Stop> stops = new ArrayList<>();
         for (final String file : filesWithStops) {
             stops.add(stop(file, revision));
@@ -64,7 +65,7 @@ public class OneStopPerPartOfFileRestructuringTest {
         return new Tour(description, stops);
     }
 
-    private static Tour tour(String description, Stop... stops) {
+    private static Tour tour(final String description, final Stop... stops) {
         return new Tour(description, Arrays.asList(stops));
     }
 


### PR DESCRIPTION
Two bugs prevented CoRT from recognizing local changes and thereby from selecting the correct hunks in a locally modified file. The first bug made CoRT recognize local changes initially at review start but prevented CoRT from handling further local changes in already modified files properly. The second bug made CoRT unable to trace local changes in a file when this file was used as a copy source in a revision greater than the revision of the last change in the file. In such a situation, CoRT used to attach any local changes to that revision pointing at the last change of the file rather than to the last revision in the file history tree, thereby ignoring the (from Subversion's point of view) artificial nodes serving as copy sources, such that the fragment tracer never saw the local changes . Both bugs are addressed by the changes in this pull request.