### PR TITLE
Feature add move detection to file history graph

### DIFF
--- a/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/SvnMoveDetectionTest.java
+++ b/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/SvnMoveDetectionTest.java
@@ -1,0 +1,175 @@
+package de.setsoftware.reviewtool.changesources.svn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.junit.Test;
+import org.tmatesoft.svn.core.SVNLogEntryPath;
+
+import de.setsoftware.reviewtool.base.ComparableWrapper;
+import de.setsoftware.reviewtool.diffalgorithms.DiffAlgorithmFactory;
+import de.setsoftware.reviewtool.model.api.IFileHistoryNode;
+import de.setsoftware.reviewtool.model.changestructure.ChangestructureFactory;
+import de.setsoftware.reviewtool.model.changestructure.FileHistoryGraph;
+
+public class SvnMoveDetectionTest {
+
+    @Test
+    public void testSimpleMoveToLaterPath() {
+        final SortedMap<String, CachedLogEntryPath> paths = new TreeMap<>();
+        paths.put("/a", new CachedLogEntryPath("/a", null, 1L, null, -1L, SVNLogEntryPath.TYPE_DELETED, 'F'));
+        paths.put("/b", new CachedLogEntryPath("/b", null, 1L, "/a", 1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        paths.put("/c", new CachedLogEntryPath("/c", null, 1L, null, -1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        final FileHistoryGraph graph = new FileHistoryGraph(DiffAlgorithmFactory.createDefault());
+        new SvnRepoRevision(StubRepo.INSTANCE, new CachedLogEntry(2L, "", "", new Date(), paths)).integrateInto(graph);
+
+        final IFileHistoryNode aNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/a",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(aNode);
+        assertEquals(IFileHistoryNode.Type.DELETED, aNode.getType());
+        assertFalse(aNode.isCopyTarget());
+
+        final IFileHistoryNode bNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/b",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(bNode);
+        assertEquals(IFileHistoryNode.Type.CHANGED, bNode.getType());
+        assertTrue(bNode.isCopyTarget());
+
+        final IFileHistoryNode cNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/c",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(cNode);
+        assertEquals(IFileHistoryNode.Type.ADDED, cNode.getType());
+        assertFalse(cNode.isCopyTarget());
+
+        assertEquals(Collections.singleton(bNode), aNode.getMoveTargets());
+        assertEquals(Collections.singleton(aNode), bNode.getMoveSources());
+    }
+
+    @Test
+    public void testSimpleMoveToEarlierPath() {
+        final SortedMap<String, CachedLogEntryPath> paths = new TreeMap<>();
+        paths.put("/a", new CachedLogEntryPath("/a", null, 1L, "/b", 1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        paths.put("/b", new CachedLogEntryPath("/b", null, 1L, null, -1L, SVNLogEntryPath.TYPE_DELETED, 'F'));
+        paths.put("/c", new CachedLogEntryPath("/c", null, 1L, null, -1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        final FileHistoryGraph graph = new FileHistoryGraph(DiffAlgorithmFactory.createDefault());
+        new SvnRepoRevision(StubRepo.INSTANCE, new CachedLogEntry(2L, "", "", new Date(), paths)).integrateInto(graph);
+
+        final IFileHistoryNode aNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/a",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(aNode);
+        assertEquals(IFileHistoryNode.Type.CHANGED, aNode.getType());
+        assertTrue(aNode.isCopyTarget());
+
+        final IFileHistoryNode bNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/b",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(bNode);
+        assertEquals(IFileHistoryNode.Type.DELETED, bNode.getType());
+        assertFalse(bNode.isCopyTarget());
+
+        final IFileHistoryNode cNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/c",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(cNode);
+        assertEquals(IFileHistoryNode.Type.ADDED, cNode.getType());
+        assertFalse(cNode.isCopyTarget());
+
+        assertEquals(Collections.singleton(aNode), bNode.getMoveTargets());
+        assertEquals(Collections.singleton(bNode), aNode.getMoveSources());
+    }
+
+    @Test
+    public void testNestedMoveToLaterPath() {
+        final FileHistoryGraph graph = new FileHistoryGraph(DiffAlgorithmFactory.createDefault());
+        final SortedMap<String, CachedLogEntryPath> paths = new TreeMap<>();
+        paths.put("/c", new CachedLogEntryPath("/c", null, 0L, null, -1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        new SvnRepoRevision(StubRepo.INSTANCE, new CachedLogEntry(1L, "", "", new Date(), paths)).integrateInto(graph);
+
+        paths.clear();
+        paths.put("/a", new CachedLogEntryPath("/a", null, 1L, null, -1L, SVNLogEntryPath.TYPE_DELETED, 'F'));
+        paths.put("/b", new CachedLogEntryPath("/b", null, 1L, "/a", 1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        paths.put("/b/c", new CachedLogEntryPath("/b/c", null, 1L, "/c", 1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        paths.put("/c", new CachedLogEntryPath("/c", null, 1L, null, -1L, SVNLogEntryPath.TYPE_DELETED, 'F'));
+        new SvnRepoRevision(StubRepo.INSTANCE, new CachedLogEntry(2L, "", "", new Date(), paths)).integrateInto(graph);
+
+        final IFileHistoryNode aNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/a",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(aNode);
+        assertEquals(IFileHistoryNode.Type.DELETED, aNode.getType());
+        assertFalse(aNode.isCopyTarget());
+
+        final IFileHistoryNode bNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/b",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(bNode);
+        assertEquals(IFileHistoryNode.Type.CHANGED, bNode.getType());
+        assertTrue(bNode.isCopyTarget());
+
+        final IFileHistoryNode cOldNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/c",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(cOldNode);
+        assertEquals(IFileHistoryNode.Type.DELETED, cOldNode.getType());
+        assertFalse(cOldNode.isCopyTarget());
+
+        final IFileHistoryNode cNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/b/c",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(cNode);
+        assertEquals(IFileHistoryNode.Type.CHANGED, cNode.getType());
+        assertTrue(cNode.isCopyTarget());
+
+        assertEquals(Collections.singleton(bNode), aNode.getMoveTargets());
+        assertEquals(Collections.singleton(aNode), bNode.getMoveSources());
+
+        assertEquals(Collections.singleton(cNode), cOldNode.getMoveTargets());
+        assertEquals(Collections.singleton(cOldNode), cNode.getMoveSources());
+    }
+
+    @Test
+    public void testNestedMoveToEarlierPath() {
+        final FileHistoryGraph graph = new FileHistoryGraph(DiffAlgorithmFactory.createDefault());
+        final SortedMap<String, CachedLogEntryPath> paths = new TreeMap<>();
+        paths.put("/c", new CachedLogEntryPath("/c", null, 0L, null, -1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        new SvnRepoRevision(StubRepo.INSTANCE, new CachedLogEntry(1L, "", "", new Date(), paths)).integrateInto(graph);
+
+        paths.clear();
+        paths.put("/a", new CachedLogEntryPath("/a", null, 1L, "/b", 1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        paths.put("/a/c", new CachedLogEntryPath("/a/c", null, 1L, "/c", 1L, SVNLogEntryPath.TYPE_ADDED, 'F'));
+        paths.put("/b", new CachedLogEntryPath("/b", null, 1L, null, -1L, SVNLogEntryPath.TYPE_DELETED, 'F'));
+        paths.put("/c", new CachedLogEntryPath("/c", null, 1L, null, -1L, SVNLogEntryPath.TYPE_DELETED, 'F'));
+        new SvnRepoRevision(StubRepo.INSTANCE, new CachedLogEntry(2L, "", "", new Date(), paths)).integrateInto(graph);
+
+        final IFileHistoryNode aNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/a",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(aNode);
+        assertEquals(IFileHistoryNode.Type.CHANGED, aNode.getType());
+        assertTrue(aNode.isCopyTarget());
+
+        final IFileHistoryNode bNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/b",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(bNode);
+        assertEquals(IFileHistoryNode.Type.DELETED, bNode.getType());
+        assertFalse(bNode.isCopyTarget());
+
+        final IFileHistoryNode cOldNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/c",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(cOldNode);
+        assertEquals(IFileHistoryNode.Type.DELETED, cOldNode.getType());
+        assertFalse(cOldNode.isCopyTarget());
+
+        final IFileHistoryNode cNode = graph.getNodeFor(ChangestructureFactory.createFileInRevision("/a/c",
+                ChangestructureFactory.createRepoRevision(ComparableWrapper.wrap(2L), StubRepo.INSTANCE)));
+        assertNotNull(cNode);
+        assertEquals(IFileHistoryNode.Type.CHANGED, cNode.getType());
+        assertTrue(cNode.isCopyTarget());
+
+        assertEquals(Collections.singleton(aNode), bNode.getMoveTargets());
+        assertEquals(Collections.singleton(bNode), aNode.getMoveSources());
+
+        assertEquals(Collections.singleton(cNode), cOldNode.getMoveTargets());
+        assertEquals(Collections.singleton(cOldNode), cNode.getMoveSources());
+    }
+}

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
@@ -35,10 +35,10 @@ abstract class AbstractSvnRevision implements SvnRevision {
                 if (copyPath != null) {
                     graph.addCopy(
                             copyPath,
-                            path,
                             ChangestructureFactory.createRepoRevision(
                                     ComparableWrapper.wrap(pathInfo.getCopyRevision()),
                                     this.getRepository()),
+                            path,
                             this.toRevision());
                 } else {
                     graph.addAddition(path, this.toRevision());

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
@@ -24,24 +24,14 @@ abstract class AbstractSvnRevision implements SvnRevision {
     void integrateInto(final IMutableFileHistoryGraph graph) {
         for (final Entry<String, CachedLogEntryPath> e : this.getChangedPaths().entrySet()) {
             final String path = e.getKey();
-
             final CachedLogEntryPath pathInfo = e.getValue();
-            final String copyPath = pathInfo.getCopyPath();
-            if (pathInfo.isDeleted()) {
+
+            if (pathInfo.isDeleted() || pathInfo.isReplaced()) {
                 graph.addDeletion(path, this.toRevision());
-            } else if (pathInfo.isReplaced()) {
-                if (copyPath != null) {
-                    graph.addReplacement(
-                            path,
-                            this.toRevision(),
-                            copyPath,
-                            ChangestructureFactory.createRepoRevision(
-                                    ComparableWrapper.wrap(pathInfo.getCopyRevision()),
-                                    this.getRepository()));
-                } else {
-                    graph.addReplacement(path, this.toRevision());
-                }
-            } else if (pathInfo.isNew()) {
+            }
+
+            if (pathInfo.isNew() || pathInfo.isReplaced()) {
+                final String copyPath = pathInfo.getCopyPath();
                 if (copyPath != null) {
                     graph.addCopy(
                             copyPath,
@@ -53,7 +43,9 @@ abstract class AbstractSvnRevision implements SvnRevision {
                 } else {
                     graph.addAddition(path, this.toRevision());
                 }
-            } else {
+            }
+
+            if (!pathInfo.isDeleted() && !pathInfo.isNew()  && !pathInfo.isReplaced()) {
                 graph.addChange(
                         path,
                         this.toRevision(),

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/CachedLogEntry.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/CachedLogEntry.java
@@ -35,6 +35,22 @@ final class CachedLogEntry implements Serializable {
         }
     }
 
+    /**
+     * Constructor. Only for testing.
+     */
+    CachedLogEntry(
+            final long revision,
+            final String message,
+            final String author,
+            final Date date,
+            final SortedMap<String, CachedLogEntryPath> paths) {
+        this.revision = revision;
+        this.message = message;
+        this.author = author;
+        this.date = date;
+        this.paths = paths;
+    }
+
     String getMessage() {
         return this.message;
     }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/CachedLogEntryPath.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/CachedLogEntryPath.java
@@ -56,6 +56,26 @@ final class CachedLogEntryPath implements Serializable {
         this.kind = mapStatusKind(status.getKind());
     }
 
+    /**
+     * Constructor. Only for testing.
+     */
+    CachedLogEntryPath(
+            final String path,
+            final File localPath,
+            final long prevRevision,
+            final String copyPath,
+            final long copyRevision,
+            final char type,
+            final char kind) {
+        this.path = path;
+        this.localPath = localPath;
+        this.prevRevision = prevRevision;
+        this.copyPath = copyPath;
+        this.copyRevision = copyRevision;
+        this.type = type;
+        this.kind = kind;
+    }
+
     private static char mapStatusKind(final SVNNodeKind nodeKind) {
         if (nodeKind.equals(SVNNodeKind.FILE)) {
             return 'F';

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryNode.java
@@ -88,6 +88,26 @@ public interface IFileHistoryNode {
     public abstract Set<? extends IFileHistoryEdge> getDescendants();
 
     /**
+     * Returns the set of nodes that constitute the move sources of this node. A path P1 is determined to has moved
+     * to path P2 in revision R if P1 is deleted in R and there is a copy from P1@R' to P2@R (with R' < R).
+     * In this case, P1@R is a move source of P2@R.
+     * Note that for movement detection to work, the deletion must be processed before the copy.
+     * Note that there may exist multiple move sources as each copy constitutes a move in this case (all copy
+     * operations are handled equally).
+     */
+    public abstract Set<? extends IFileHistoryNode> getMoveSources();
+
+    /**
+     * Returns the set of nodes that constitute the move targets of this node. A path P1 is determined to has moved
+     * to path P2 in revision R if P1 is deleted in R and there is a copy from P1@R' to P2@R (with R' < R).
+     * In this case, P2@R is a move target of P1@R.
+     * Note that for movement detection to work, the deletion must be processed before the copy.
+     * Note that there may exist multiple move targets as each copy constitutes a move in this case (all copy
+     * operations are handled equally).
+     */
+    public abstract Set<? extends IFileHistoryNode> getMoveTargets();
+
+    /**
      * Computes {@link FileDiff}s from passed history node to this one. There may be none (if {@code from} is not an
      * ancestor), one (if {@code from} is reached by a single path backwards in history), or multiple ones
      * (if {@code from} can be reached by multiple paths backwards in history).

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
@@ -37,24 +37,6 @@ public interface IMutableFileHistoryGraph extends IFileHistoryGraph, Serializabl
             IRevision revision);
 
     /**
-     * Adds the information that the path {@code path} was replaced by a fresh path (file or directory) in revision
-     * {@code revision}.
-     */
-    public abstract void addReplacement(
-            String path,
-            IRevision revision);
-
-    /**
-     * Adds the information that the path {@code path} was replaced by a fresh path (file or directory) in revision
-     * {@code revision}, copied from {@code pathFrom} at revision {@code revisionFrom}.
-     */
-    public abstract void addReplacement(
-            String path,
-            IRevision revision,
-            String pathFrom,
-            IRevision revisionFrom);
-
-    /**
      * Adds the information that the path {@code pathFrom} at revision {@code revisionFrom} was copied to
      * path {@code pathTo} in revision {@code revisionTo}.
      */
@@ -63,5 +45,4 @@ public interface IMutableFileHistoryGraph extends IFileHistoryGraph, Serializabl
             String pathTo,
             IRevision revisionFrom,
             IRevision revisionTo);
-
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
@@ -42,7 +42,7 @@ public interface IMutableFileHistoryGraph extends IFileHistoryGraph, Serializabl
      */
     public abstract void addCopy(
             String pathFrom,
-            String pathTo,
             IRevision revisionFrom,
+            String pathTo,
             IRevision revisionTo);
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryNode.java
@@ -17,4 +17,9 @@ public interface IMutableFileHistoryNode extends IFileHistoryNode, Serializable 
     @Override
     public abstract Set<? extends IMutableFileHistoryEdge> getDescendants();
 
+    @Override
+    public abstract Set<? extends IMutableFileHistoryNode> getMoveSources();
+
+    @Override
+    public abstract Set<? extends IMutableFileHistoryNode> getMoveTargets();
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
@@ -52,7 +52,10 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
             final IRevision revision) {
 
         final IRevisionedFile file = ChangestructureFactory.createFileInRevision(path, revision);
-        this.getOrCreateConnectedNode(file, IFileHistoryNode.Type.ADDED);
+        final ProxyableFileHistoryNode node = this.getOrCreateConnectedNode(file, IFileHistoryNode.Type.ADDED);
+        if (node.getType().equals(IFileHistoryNode.Type.DELETED)) {
+            node.makeReplaced();
+        }
     }
 
     @Override
@@ -97,47 +100,21 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
     }
 
     @Override
-    public final void addReplacement(
-            final String path,
-            final IRevision revision) {
-
-        this.addDeletion(path, revision);
-        this.addAddition(path, revision);
-    }
-
-    @Override
-    public final void addReplacement(
-            final String path,
-            final IRevision revision,
-            final String pathFrom,
-            final IRevision revisionFrom) {
-
-        this.addDeletion(path, revision);
-        this.addCopy(pathFrom, path, revisionFrom, revision, IFileHistoryNode.Type.ADDED);
-    }
-
-    @Override
     public final void addCopy(
             final String pathFrom,
             final String pathTo,
             final IRevision revisionFrom,
             final IRevision revisionTo) {
-        this.addCopy(pathFrom, pathTo, revisionFrom, revisionTo, IFileHistoryNode.Type.CHANGED);
-    }
-
-    private void addCopy(
-            final String pathFrom,
-            final String pathTo,
-            final IRevision revisionFrom,
-            final IRevision revisionTo,
-            final IFileHistoryNode.Type nodeType) {
 
         final IRevisionedFile fileFrom = ChangestructureFactory.createFileInRevision(pathFrom, revisionFrom);
         final IRevisionedFile fileTo = ChangestructureFactory.createFileInRevision(pathTo, revisionTo);
 
         final ProxyableFileHistoryNode fromNode =
                 this.getOrCreateConnectedNode(fileFrom, IFileHistoryNode.Type.UNCONFIRMED);
-        final ProxyableFileHistoryNode toNode = this.getOrCreateUnconnectedNode(fileTo, nodeType);
+        final ProxyableFileHistoryNode toNode = this.getOrCreateUnconnectedNode(fileTo, IFileHistoryNode.Type.CHANGED);
+        if (toNode.getType().equals(IFileHistoryNode.Type.DELETED)) {
+            toNode.makeReplaced();
+        }
 
         this.createMissingChildren(fromNode);
 
@@ -430,10 +407,6 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
                 if (!ancestors.isEmpty()) {
                     this.addNodeWithAncestors(node, ancestors, IFileHistoryEdge.Type.NORMAL);
                 }
-            }
-        } else {
-            if (nodeType.equals(IFileHistoryNode.Type.ADDED)) {
-                node.makeReplaced();
             }
         }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
@@ -102,8 +102,8 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
     @Override
     public final void addCopy(
             final String pathFrom,
-            final String pathTo,
             final IRevision revisionFrom,
+            final String pathTo,
             final IRevision revisionTo) {
 
         final IRevisionedFile fileFrom = ChangestructureFactory.createFileInRevision(pathFrom, revisionFrom);
@@ -161,8 +161,8 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
                 final String childPath = child.getFile().getPath();
                 this.addCopy(
                         childPath,
-                        toParentPath.concat(childPath.substring(fromParentPath.length())),
                         fromRevision,
+                        toParentPath.concat(childPath.substring(fromParentPath.length())),
                         toRevision);
             }
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryNode.java
@@ -16,7 +16,7 @@ import de.setsoftware.reviewtool.model.api.IRevisionedFile;
  */
 public final class FileHistoryNode extends ProxyableFileHistoryNode {
 
-    private static final long serialVersionUID = 7938054839176372206L;
+    private static final long serialVersionUID = 2567109993505151053L;
 
     private final FileHistoryGraph graph;
     private final IRevisionedFile file;
@@ -24,6 +24,8 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
     private final Set<ProxyableFileHistoryEdge> descendants;
     private transient ProxyableFileHistoryNode parent;
     private final Set<ProxyableFileHistoryNode> children;
+    private final Set<ProxyableFileHistoryNode> moveSources;
+    private final Set<ProxyableFileHistoryNode> moveTargets;
     private Type type;
     private boolean hasAllChildren;
 
@@ -39,6 +41,8 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
         this.ancestors = new LinkedHashSet<>();
         this.descendants = new LinkedHashSet<>();
         this.children = new LinkedHashSet<>();
+        this.moveSources = new LinkedHashSet<>();
+        this.moveTargets = new LinkedHashSet<>();
         this.type = type;
         this.hasAllChildren = false;
     }
@@ -56,6 +60,8 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
             final Set<ProxyableFileHistoryEdge> descendants,
             final ProxyableFileHistoryNode parent,
             final Set<ProxyableFileHistoryNode> children,
+            final Set<ProxyableFileHistoryNode> moveSources,
+            final Set<ProxyableFileHistoryNode> moveTargets,
             final Type type) {
 
         this.graph = graph;
@@ -64,6 +70,8 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
         this.descendants = descendants;
         this.parent = parent;
         this.children = children;
+        this.moveSources = moveSources;
+        this.moveTargets = moveTargets;
         this.type = type;
     }
 
@@ -90,6 +98,16 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
     @Override
     public Set<ProxyableFileHistoryEdge> getDescendants() {
         return this.descendants;
+    }
+
+    @Override
+    public Set<? extends ProxyableFileHistoryNode> getMoveSources() {
+        return this.moveSources;
+    }
+
+    @Override
+    public Set<? extends ProxyableFileHistoryNode> getMoveTargets() {
+        return this.moveTargets;
     }
 
     @Override
@@ -151,6 +169,16 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
         final ProxyableFileHistoryEdge edge = new FileHistoryEdge(this.graph, this, descendant, type);
         this.descendants.add(edge);
         descendant.addAncestor(edge);
+    }
+
+    @Override
+    void addMoveSource(final ProxyableFileHistoryNode node) {
+        this.moveSources.add(node);
+    }
+
+    @Override
+    void addMoveTarget(final ProxyableFileHistoryNode node) {
+        this.moveTargets.add(node);
     }
 
     @Override
@@ -246,6 +274,8 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
                 this.descendants,
                 this.parent == null ? null : this.parent.getFile(),
                 toFiles(this.children),
+                toFiles(this.moveSources),
+                toFiles(this.moveTargets),
                 this.type);
     }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ProxyableFileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/ProxyableFileHistoryNode.java
@@ -18,6 +18,12 @@ public abstract class ProxyableFileHistoryNode extends AbstractFileHistoryNode i
     @Override
     public abstract Set<? extends ProxyableFileHistoryEdge> getDescendants();
 
+    @Override
+    public abstract Set<? extends ProxyableFileHistoryNode> getMoveSources();
+
+    @Override
+    public abstract Set<? extends ProxyableFileHistoryNode> getMoveTargets();
+
     /**
      * Adds some nearest ancestor {@link ProxyableFileHistoryNode}.
      * This operation is called internally when this node starts being a descendant
@@ -36,6 +42,16 @@ public abstract class ProxyableFileHistoryNode extends AbstractFileHistoryNode i
      * Adds a descendant {@link ProxyableFileHistoryNode} of this node.
      */
     abstract void addDescendant(final ProxyableFileHistoryNode descendant, final IFileHistoryEdge.Type type);
+
+    /**
+     * Adds a {@link ProxyableFileHistoryNode} as move source.
+     */
+    abstract void addMoveSource(final ProxyableFileHistoryNode node);
+
+    /**
+     * Adds a {@link ProxyableFileHistoryNode} as move target.
+     */
+    abstract void addMoveTarget(final ProxyableFileHistoryNode node);
 
     /**
      * Makes this node a deleted node. Requires that the node is a {@link Type#ADDED} or {@link Type#CHANGED} node.

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryNode.java
@@ -161,6 +161,28 @@ final class VirtualFileHistoryNode extends AbstractFileHistoryNode {
         return edges;
     }
 
+    @Override
+    public Set<? extends IFileHistoryNode> getMoveSources() {
+        final Set<IFileHistoryNode> moveSources = new LinkedHashSet<>();
+        for (final IFileHistoryNode node : this.nodes) {
+            for (final IFileHistoryNode moveSource : node.getMoveSources()) {
+                moveSources.add(this.graph.getNodeFor(moveSource.getFile()));
+            }
+        }
+        return moveSources;
+    }
+
+    @Override
+    public Set<? extends IFileHistoryNode> getMoveTargets() {
+        final Set<IFileHistoryNode> moveTargets = new LinkedHashSet<>();
+        for (final IFileHistoryNode node : this.nodes) {
+            for (final IFileHistoryNode moveTarget : node.getMoveTargets()) {
+                moveTargets.add(this.graph.getNodeFor(moveTarget.getFile()));
+            }
+        }
+        return moveTargets;
+    }
+
     /**
      * Adds an ancestor node explicitly. This is necessary if a connection between two different revisions is needed.
      * @param ancestor The ancestor node to add.

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphGetLatestFilesTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphGetLatestFilesTest.java
@@ -47,7 +47,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testCopy() {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         assertEquals(
                 Arrays.asList(file("a", 5), file("b", 6)),
                 g.getLatestFiles(file("a", 1), false));
@@ -85,7 +85,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testMoveOneWay() {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         g.addDeletion("a", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6)),
@@ -103,7 +103,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addDeletion("a", rev(6));
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6)),
                 g.getLatestFiles(file("a", 1), false));
@@ -119,10 +119,10 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testMoveWithMultipleCopies() {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)) );
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         g.addDeletion("a", rev(6));
-        g.addCopy("a", "c", rev(5), rev(6));
-        g.addCopy("a", "d", rev(5), rev(6));
+        g.addCopy("a", rev(5), "c", rev(6));
+        g.addCopy("a", rev(5), "d", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6), file("c", 6), file("d", 6)),
                 g.getLatestFiles(file("a", 1), false));
@@ -145,11 +145,11 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addDeletion("a", rev(11));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addDeletion("b", rev(21));
-        g.addCopy("b", "c", rev(20), rev(21));
+        g.addCopy("b", rev(20), "c", rev(21));
         g.addDeletion("c", rev(31));
-        g.addCopy("c", "d", rev(30), rev(31));
+        g.addCopy("c", rev(30), "d", rev(31));
 
         assertEquals(
                 Arrays.asList(file("d", 31)),
@@ -167,7 +167,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addDeletion("a", rev(11));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addDeletion("b", rev(21));
 
         assertEquals(
@@ -182,7 +182,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testMoveAndDeleteAfterwardsStartWithDeletion() {
         final IMutableFileHistoryGraph g = graph();
         g.addDeletion("a", rev(11));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addDeletion("b", rev(21));
 
         assertEquals(
@@ -199,7 +199,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addChange("a", rev(6), Collections.singleton(rev(5)));
         g.addDeletion("a", rev(20));
-        g.addCopy("a", "b", rev(5), rev(23));
+        g.addCopy("a", rev(5), "b", rev(23));
         assertEquals(
                 Arrays.asList(file("b", 23)),
                 g.getLatestFiles(file("a", 1), false));
@@ -218,7 +218,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testCopyWithRevisionSkipStartWithDeletion() {
         final IMutableFileHistoryGraph g = graph();
         g.addDeletion("a", rev(20));
-        g.addCopy("a", "b", rev(5), rev(23));
+        g.addCopy("a", rev(5), "b", rev(23));
         assertEquals(
                 Arrays.asList(file("a", 1)),
                 g.getLatestFiles(file("a", 1), false));
@@ -242,8 +242,8 @@ public class FileHistoryGraphGetLatestFilesTest {
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addChange("a", rev(6), Collections.singleton(rev(5)));
         g.addDeletion("a", rev(20));
-        g.addCopy("a", "b", rev(5), rev(23));
-        g.addCopy("b", "c", rev(23), rev(24));
+        g.addCopy("a", rev(5), "b", rev(23));
+        g.addCopy("b", rev(23), "c", rev(24));
         assertEquals(
                 Arrays.asList(file("b", 23), file("c", 24)),
                 g.getLatestFiles(file("a", 1), false));
@@ -263,7 +263,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addChange("a/x", rev(2), Collections.singleton(rev(1)));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addChange("a/x", rev(11), Collections.singleton(rev(10)));
         g.addChange("b/x", rev(11), Collections.singleton(rev(10)));
         g.addDeletion("a", rev(13));

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
@@ -893,7 +893,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNode = g.getNodeFor(aRevPrev);
         assertEquals(aRevPrev, aNode.getFile());
@@ -943,7 +944,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNodePrev = g.getNodeFor(aRevPrev);
         assertEquals(aRevPrev, aNodePrev.getFile());
@@ -985,7 +987,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addDeletion(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addAddition(xRevReplaced.getPath(), xRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNode = g.getNodeFor(aRevPrev);
@@ -1067,7 +1070,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addDeletion(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addAddition(xRevReplaced.getPath(), xRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNodeReplaced = g.getNodeFor(aRevReplaced);
@@ -2132,9 +2136,10 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
         g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
-        g.addReplacement(bRevReplaced.getPath(), bRevReplaced.getRevision(),
-                bRevOrig.getPath(), bRevOrig.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2212,9 +2217,10 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
         g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
-        g.addReplacement(bRevReplaced.getPath(), bRevReplaced.getRevision(),
-                bRevOrig.getPath(), bRevOrig.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
@@ -1587,6 +1587,10 @@ public final class FileHistoryGraphTest {
         final FileHistoryEdge trunkEdge = new FileHistoryEdge(g, trunkNode, trunkNode2, IFileHistoryEdge.Type.NORMAL);
         assertEquals(Collections.singleton(trunkEdge), trunkNode.getDescendants());
         assertEquals(Collections.singleton(trunkEdge), trunkNode2.getAncestors());
+
+        // move not detected as deletion was processed after copy
+        assertEquals(Collections.emptySet(), aDelNode.getMoveTargets());
+        assertEquals(Collections.emptySet(), aCopyNode.getMoveSources());
     }
 
     @Test
@@ -1643,6 +1647,9 @@ public final class FileHistoryGraphTest {
 
         assertEquals(Collections.emptySet(), trunkNode.getDescendants());
         assertEquals(Collections.singleton(createAlphaNode(repo, g, trunkNode2)), trunkNode2.getAncestors());
+
+        assertEquals(Collections.singleton(aCopyNode), aDelNode.getMoveTargets());
+        assertEquals(Collections.singleton(aDelNode), aCopyNode.getMoveSources());
     }
 
     @Test
@@ -2833,6 +2840,12 @@ public final class FileHistoryGraphTest {
         assertEquals(new HashSet<>(Arrays.asList(xyEdgeCopy, xyEdgeDel)), xNode.getDescendants());
         assertEquals(Collections.singleton(xyEdgeCopy), yNode.getAncestors());
         assertEquals(Collections.singleton(xyEdgeDel), xDelNode.getAncestors());
+
+        // move not detected as deletion was processed after copy
+        assertEquals(Collections.emptySet(), xDelNode.getMoveTargets());
+        assertEquals(Collections.emptySet(), yNode.getMoveSources());
+        assertEquals(Collections.emptySet(), aDelNode.getMoveTargets());
+        assertEquals(Collections.emptySet(), aCopyNode.getMoveSources());
     }
 
     @Test
@@ -2910,6 +2923,11 @@ public final class FileHistoryGraphTest {
         assertEquals(new HashSet<>(Arrays.asList(xyEdgeCopy, xyEdgeDel)), xNode.getDescendants());
         assertEquals(Collections.singleton(xyEdgeCopy), yNode.getAncestors());
         assertEquals(Collections.singleton(xyEdgeDel), xDelNode.getAncestors());
+
+        assertEquals(Collections.singleton(yNode), xDelNode.getMoveTargets());
+        assertEquals(Collections.singleton(xDelNode), yNode.getMoveSources());
+        assertEquals(Collections.singleton(aCopyNode), aDelNode.getMoveTargets());
+        assertEquals(Collections.singleton(aDelNode), aCopyNode.getMoveSources());
     }
 
     @Test

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
@@ -705,7 +705,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b/y", trunk3Rev.getRevision());
 
-        g.addCopy(aRev2.getPath(), bRevOrig.getPath(), aRev2.getRevision(), bRevOrig.getRevision());
+        g.addCopy(aRev2.getPath(), aRev2.getRevision(), bRevOrig.getPath(), bRevOrig.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final IRevisionedFile trunk4Rev =
@@ -1368,7 +1368,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1417,7 +1417,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
         g.addChange(aRevCopy.getPath(), aRevCopy.getRevision(), Collections.singleton(aRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -1479,8 +1479,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy2 =
                 ChangestructureFactory.createFileInRevision("/trunk/c", new TestRepoRevision(repo, 5L));
 
-        g.addCopy(aRevChanged.getPath(), aRevCopy.getPath(), aRevChanged.getRevision(), aRevCopy.getRevision());
-        g.addCopy(aRevSource2.getPath(), aRevCopy2.getPath(), aRevSource2.getRevision(), aRevCopy2.getRevision());
+        g.addCopy(aRevChanged.getPath(), aRevChanged.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
+        g.addCopy(aRevSource2.getPath(), aRevSource2.getRevision(), aRevCopy2.getPath(), aRevCopy2.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1543,7 +1543,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -1602,7 +1602,7 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1662,7 +1662,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1720,7 +1720,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y", new TestRepoRevision(repo, 3L));
 
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1782,7 +1782,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", trunkRev.getRevision());
 
-        g.addCopy(trunkRevOrig.getPath(), xRev.getPath(), trunkRevOrig.getRevision(), xRev.getRevision());
+        g.addCopy(trunkRevOrig.getPath(), trunkRevOrig.getRevision(), xRev.getPath(), xRev.getRevision());
 
         final ProxyableFileHistoryNode trunkOrigNode = g.getNodeFor(trunkRevOrig);
         assertEquals(trunkRevOrig, trunkOrigNode.getFile());
@@ -1870,7 +1870,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", trunkRev.getRevision());
 
-        g.addCopy(oldTrunkRev.getPath(), xRev.getPath(), oldTrunkRev.getRevision(), xRev.getRevision());
+        g.addCopy(oldTrunkRev.getPath(), oldTrunkRev.getRevision(), xRev.getPath(), xRev.getRevision());
 
         final ProxyableFileHistoryNode trunkCopySourceNode = g.getNodeFor(oldTrunkRev);
         assertEquals(oldTrunkRev, trunkCopySourceNode.getFile());
@@ -1935,7 +1935,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final IRevisionedFile aRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
@@ -1978,7 +1978,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final IRevisionedFile aRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
@@ -2028,7 +2028,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevDel =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2080,7 +2080,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevDel =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final ProxyableFileHistoryNode aNode = g.getNodeFor(aRevOrig);
@@ -2135,11 +2135,11 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRevReplaced.getPath(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2216,11 +2216,11 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRevReplaced.getPath(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2292,7 +2292,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevChanged =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addChange(aRevChanged.getPath(), aRevChanged.getRevision(), Collections.singleton(aRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2344,7 +2344,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevChanged =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addChange(aRevChanged.getPath(), aRevChanged.getRevision(), Collections.singleton(xRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2398,7 +2398,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevChanged =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRevChanged.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addChange(aRevChanged.getPath(), aRevChanged.getRevision(), Collections.singleton(yRev.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2458,8 +2458,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2528,8 +2528,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
 
         final ProxyableFileHistoryNode bOrigNode = g.getNodeFor(bRevOrig);
         assertEquals(bRevOrig, bOrigNode.getFile());
@@ -2583,8 +2583,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", new TestRepoRevision(repo, 3L));
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
 
         final ProxyableFileHistoryNode bOrigNode = g.getNodeFor(bRevOrig);
         assertEquals(bRevOrig, bOrigNode.getFile());
@@ -2649,8 +2649,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
         g.addChange(bRev.getPath(), bRev.getRevision(), Collections.singleton(bRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2720,8 +2720,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
         g.addChange(bRev.getPath(), bRev.getRevision(), Collections.singleton(bRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode bOrigNode = g.getNodeFor(bRevOrig);
@@ -2779,7 +2779,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(xRevDel.getPath(), xRevDel.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2857,7 +2857,7 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
         g.addDeletion(xRevDel.getPath(), xRevDel.getRevision());
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
@@ -390,7 +390,7 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalCopyOfLatestRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/e.txt", this.rev(2), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(2), "/dir1/dir2/e.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -417,7 +417,7 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalCopyOfOlderRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/e.txt", this.rev(1), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(1), "/dir1/dir2/e.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(1)));
@@ -518,7 +518,7 @@ public class VirtualFileHistoryGraphTest {
     public void testLocalReplacementByCopyOfLatestRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
         localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(2), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(2), "/dir1/dir2/c.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -555,7 +555,7 @@ public class VirtualFileHistoryGraphTest {
     public void testLocalReplacementByCopyOfOlderRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
         localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(1), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(1), "/dir1/dir2/c.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(1)));

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
@@ -78,7 +78,8 @@ public class VirtualFileHistoryGraphTest {
         // revision 2
         this.remoteFileHistoryGraph.addChange("/dir1/dir2/a.txt", this.rev(2), Collections.singleton(this.rev(1)));
         this.remoteFileHistoryGraph.addDeletion("/dir1/dir2/b.txt", this.rev(2));
-        this.remoteFileHistoryGraph.addReplacement("/dir1/dir2/c.txt", this.rev(2));
+        this.remoteFileHistoryGraph.addDeletion("/dir1/dir2/c.txt", this.rev(2));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2/c.txt", this.rev(2));
     }
 
     @Test
@@ -454,9 +455,12 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalReplacement() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addReplacement("/dir1/dir2/a.txt", this.localRev());
-        localGraph.addReplacement("/dir1/dir2/c.txt", this.localRev());
-        localGraph.addReplacement("/dir1/dir2/d.txt", this.localRev());
+        localGraph.addDeletion("/dir1/dir2/a.txt", this.localRev());
+        localGraph.addAddition("/dir1/dir2/a.txt", this.localRev());
+        localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addAddition("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addDeletion("/dir1/dir2/d.txt", this.localRev());
+        localGraph.addAddition("/dir1/dir2/d.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -513,7 +517,8 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalReplacementByCopyOfLatestRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addReplacement("/dir1/dir2/c.txt", this.localRev(), "/dir1/dir2/a.txt", this.rev(2));
+        localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(2), this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -549,7 +554,8 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalReplacementByCopyOfOlderRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addReplacement("/dir1/dir2/c.txt", this.localRev(), "/dir1/dir2/a.txt", this.rev(1));
+        localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(1), this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(1)));


### PR DESCRIPTION
This set of changes implements move detection in FileHistoryGraph. This has been done in order not to require the DefaultChangeSource class to take care of it (as it obviously belongs to FileHistoryGraph). Note that in order to make the move detection work with Subversion (or any other SCM system), the deletion of the moved-away path needs to be processed before the addition of the moved-to path. Consequently, the code in AbstractSvnRevision mapping a Subversion commit to FileHistoryGraph operations has been rewritten accordingly with move detection in mind.

Note that move detection has been implemented generically, i.e. it is not possible for concrete change source implementations to take advantage of the underlying SCM's abilities wrt. move detection. The advantage of the proposed solution here is that it works uniformly across all SCM systems.