### PR TITLE
Fix svn changeset analysis

### DIFF
--- a/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/StubRepo.java
+++ b/de.setsoftware.reviewtool.changesources.svn.tests/src/de/setsoftware/reviewtool/changesources/svn/StubRepo.java
@@ -3,6 +3,7 @@ package de.setsoftware.reviewtool.changesources.svn;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -81,5 +82,10 @@ public final class StubRepo extends AbstractRepository implements ISvnRepo {
     @Override
     public void setFileHistoryGraph(final IMutableFileHistoryGraph fileHistoryGraph) {
         this.fileHistoryGraph = fileHistoryGraph;
+    }
+
+    @Override
+    public Set<? extends File> getFiles(final String path, final IRepoRevision<?> revision) {
+        return Collections.emptySet();
     }
 }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
@@ -35,10 +35,10 @@ abstract class AbstractSvnRevision implements SvnRevision {
                 if (copyPath != null) {
                     graph.addCopy(
                             copyPath,
-                            path,
                             ChangestructureFactory.createRepoRevision(
                                     ComparableWrapper.wrap(pathInfo.getCopyRevision()),
                                     this.getRepository()),
+                            path,
                             this.toRevision());
                 } else {
                     graph.addAddition(path, this.toRevision());

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
@@ -1,14 +1,28 @@
 package de.setsoftware.reviewtool.changesources.svn;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 import de.setsoftware.reviewtool.base.ComparableWrapper;
+import de.setsoftware.reviewtool.base.Pair;
+import de.setsoftware.reviewtool.base.tree.DepthFirstTraversalTreeNodeIterator;
+import de.setsoftware.reviewtool.base.tree.OrderPreservingTreeNode;
+import de.setsoftware.reviewtool.base.tree.TreeLeftToRightChildOrderStrategy;
+import de.setsoftware.reviewtool.base.tree.TreeNodeIterator;
+import de.setsoftware.reviewtool.base.tree.TreePreOrderRootNodeStrategy;
 import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
+import de.setsoftware.reviewtool.model.api.IRepoRevision;
+import de.setsoftware.reviewtool.model.api.IRepository;
+import de.setsoftware.reviewtool.model.api.IRevision;
 import de.setsoftware.reviewtool.model.changestructure.ChangestructureFactory;
 
 /**
@@ -22,33 +36,97 @@ abstract class AbstractSvnRevision implements SvnRevision {
      * @param revision The revision to process,
      */
     void integrateInto(final IMutableFileHistoryGraph graph) {
+        final OrderPreservingTreeNode<String, Boolean> addedPaths = OrderPreservingTreeNode.createRoot(null);
+        final OrderPreservingTreeNode<String, Boolean> addedLeafs = OrderPreservingTreeNode.createRoot(null);
+
         for (final Entry<String, CachedLogEntryPath> e : this.getChangedPaths().entrySet()) {
             final String path = e.getKey();
             final CachedLogEntryPath pathInfo = e.getValue();
+            final IRevision revision = this.toRevision();
 
             if (pathInfo.isDeleted() || pathInfo.isReplaced()) {
-                graph.addDeletion(path, this.toRevision());
+                final List<String> pathKey = makePathKey(path);
+                if (Optional.ofNullable(addedPaths.getNearestValue(pathKey)).orElse(false)) {
+                    // this path or some of its parents has been added as a copy in this commit:
+                    // retrieve node of deleted or replaced path in order to act upon its file leafs
+                    final OrderPreservingTreeNode<String, Boolean> pathNode = addedLeafs.getNode(pathKey);
+                    // pathNode is null if a directory containing no file leafs is deleted.
+                    // In this case, however, we need not do anything wrt. the file history graph.
+                    if (pathNode != null) {
+                        // iterate over the previously added leafs and remove them again from the file history graph
+                        final TreeNodeIterator<
+                                String,
+                                Boolean,
+                                OrderPreservingTreeNode<String, Boolean>> it =
+                                        new DepthFirstTraversalTreeNodeIterator<>(
+                                                pathNode,
+                                                new TreePreOrderRootNodeStrategy<>(),
+                                                new TreeLeftToRightChildOrderStrategy<>());
+
+                        while (it.hasNext()) {
+                            final Pair<List<String>, OrderPreservingTreeNode<String, Boolean>> entry = it.next();
+                            final OrderPreservingTreeNode<String, Boolean> node = entry.getSecond();
+                            // check if we found a leaf
+                            if (Optional.ofNullable(node.getValue()).orElse(false)) {
+                                final String deletedPath = String.join("/", entry.getFirst());
+                                graph.addDeletion(deletedPath.isEmpty() ? path : path + "/" + deletedPath, revision);
+                            }
+                        }
+
+                        // remove all the leafs at one go
+                        pathNode.getParent().removeNode(pathNode);
+                    }
+                } else {
+                    // no parent path has been added as a copy in this commit:
+                    // check ancestor revision for contents of this path and remove all leafs
+                    for (final ISvnRepo.File deletedFile :
+                            this.getRelevantFilePaths(pathInfo, path, pathInfo.getAncestorRevision())) {
+                        graph.addDeletion(deletedFile.getName(), revision);
+                    }
+                }
             }
 
             if (pathInfo.isNew() || pathInfo.isReplaced()) {
                 final String copyPath = pathInfo.getCopyPath();
                 if (copyPath != null) {
-                    graph.addCopy(
-                            copyPath,
+                    final long copyRevisionNumber = pathInfo.getCopyRevision();
+                    final IRepoRevision<ComparableWrapper<Long>> copyRevision =
                             ChangestructureFactory.createRepoRevision(
-                                    ComparableWrapper.wrap(pathInfo.getCopyRevision()),
-                                    this.getRepository()),
-                            path,
-                            this.toRevision());
-                } else {
-                    graph.addAddition(path, this.toRevision());
+                                    ComparableWrapper.wrap(copyRevisionNumber),
+                                    this.getRepository());
+
+                    if (pathInfo.isDir()) {
+                        final int copyPathLen = copyPath.length();
+
+                        for (final ISvnRepo.File copySource :
+                                this.getRelevantFilePaths(pathInfo, copyPath, copyRevisionNumber)) {
+                            final String copySourcePath = copySource.getName();
+                            final String copyTargetPath = path + copySourcePath.substring(copyPathLen);
+                            graph.addCopy(
+                                    copySourcePath,
+                                    copyRevision,
+                                    copyTargetPath,
+                                    revision);
+                            addedLeafs.putValue(makePathKey(copyTargetPath), true);
+                        }
+
+                        addedPaths.putValue(makePathKey(path), true);
+                    } else if (pathInfo.isFile()) {
+                        graph.addCopy(
+                                copyPath,
+                                copyRevision,
+                                path,
+                                revision);
+                    }
+                } else if (pathInfo.isFile()) {
+                    graph.addAddition(path, revision);
                 }
             }
 
-            if (!pathInfo.isDeleted() && !pathInfo.isNew()  && !pathInfo.isReplaced()) {
+            if (!pathInfo.isDeleted() && !pathInfo.isNew()  && !pathInfo.isReplaced() && pathInfo.isFile()) {
                 graph.addChange(
                         path,
-                        this.toRevision(),
+                        revision,
                         Collections.singleton(ChangestructureFactory.createRepoRevision(
                                 ComparableWrapper.wrap(e.getValue().getAncestorRevision()),
                                 this.getRepository())));
@@ -74,5 +152,51 @@ abstract class AbstractSvnRevision implements SvnRevision {
         }
 
         return result;
+    }
+
+    /**
+     * Returns all relevant file paths for the given {@link CachedLogEntryPath} object.
+     * If the given {@link CachedLogEntryPath} object describes a file, only this file is returned.
+     * If the given {@link CachedLogEntryPath} object describes a directory,
+     * {@link IRepository#getFiles(String, IRepoRevision)} is called on the underlying repository and its result
+     * is returned.
+     *
+     * @param pathInfo The {@link CachedLogEntryPath} object.
+     * @param revisionNumber The revision number where to perform path lookup if necessary.
+     * @return A set of relevant file paths.
+     */
+    private Set<? extends ISvnRepo.File> getRelevantFilePaths(
+            final CachedLogEntryPath pathInfo,
+            final String path,
+            final long revisionNumber) {
+
+        if (pathInfo.isFile()) {
+            return new LinkedHashSet<>(Arrays.asList(new ISvnRepo.File() {
+                @Override
+                public String getName() {
+                    return path;
+                }
+            }));
+        } else if (pathInfo.isDir()) {
+            final IRepoRevision<?> revision = ChangestructureFactory.createRepoRevision(
+                    ComparableWrapper.wrap(revisionNumber),
+                    this.getRepository());
+            return this.getRepository().getFiles(path, revision);
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Converts a path into a list of keys suitable for the path trie.
+     * @param path The path.
+     * @return The list of keys.
+     */
+    private static List<String> makePathKey(final String path) {
+        if (path.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final List<String> pathComponents = Arrays.asList(path.split("/"));
+        return pathComponents.subList(1, pathComponents.size());
     }
 }

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/AbstractSvnRevision.java
@@ -24,24 +24,14 @@ abstract class AbstractSvnRevision implements SvnRevision {
     void integrateInto(final IMutableFileHistoryGraph graph) {
         for (final Entry<String, CachedLogEntryPath> e : this.getChangedPaths().entrySet()) {
             final String path = e.getKey();
-
             final CachedLogEntryPath pathInfo = e.getValue();
-            final String copyPath = pathInfo.getCopyPath();
-            if (pathInfo.isDeleted()) {
+
+            if (pathInfo.isDeleted() || pathInfo.isReplaced()) {
                 graph.addDeletion(path, this.toRevision());
-            } else if (pathInfo.isReplaced()) {
-                if (copyPath != null) {
-                    graph.addReplacement(
-                            path,
-                            this.toRevision(),
-                            copyPath,
-                            ChangestructureFactory.createRepoRevision(
-                                    ComparableWrapper.wrap(pathInfo.getCopyRevision()),
-                                    this.getRepository()));
-                } else {
-                    graph.addReplacement(path, this.toRevision());
-                }
-            } else if (pathInfo.isNew()) {
+            }
+
+            if (pathInfo.isNew() || pathInfo.isReplaced()) {
+                final String copyPath = pathInfo.getCopyPath();
                 if (copyPath != null) {
                     graph.addCopy(
                             copyPath,
@@ -53,7 +43,9 @@ abstract class AbstractSvnRevision implements SvnRevision {
                 } else {
                     graph.addAddition(path, this.toRevision());
                 }
-            } else {
+            }
+
+            if (!pathInfo.isDeleted() && !pathInfo.isNew()  && !pathInfo.isReplaced()) {
                 graph.addChange(
                         path,
                         this.toRevision(),

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/ISvnRepo.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/ISvnRepo.java
@@ -2,6 +2,7 @@ package de.setsoftware.reviewtool.changesources.svn;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.runtime.IPath;
 import org.tmatesoft.svn.core.ISVNLogEntryHandler;
@@ -9,12 +10,24 @@ import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNURL;
 
 import de.setsoftware.reviewtool.model.api.IMutableFileHistoryGraph;
+import de.setsoftware.reviewtool.model.api.IRepoRevision;
 import de.setsoftware.reviewtool.model.api.IRepository;
 
 /**
  * Interface to a remote Subversion repository.
  */
 interface ISvnRepo extends IRepository {
+
+    /**
+     * Represents a versioned file in a repository.
+     */
+    public interface File {
+
+        /**
+         * Returns the name of this file.
+         */
+        public abstract String getName();
+    }
 
     /**
      * Returns the URL of the repository.
@@ -45,6 +58,21 @@ interface ISvnRepo extends IRepository {
      * Returns the latest revision of this repository.
      */
     public abstract long getLatestRevision() throws SVNException;
+
+    /**
+     * Returns all files in a directory given its path and revision.
+     * If the path points to a file, only this file is returned.
+     * If the path points to a directory, this operation is applied to all of its children,
+     * concatenating the resulting lists.
+     * Returns an empty set if an error occurred.
+     * Note that the revision passed is used for both path lookup and tree entry lookup. It is not possible to specify
+     * a peg revision for path lookup and an operating revision for tree entry lookup.
+     *
+     * @param path The path to the tree entry (typically a directory) the children of which are to be returned.
+     * @param revision The revision at which to look up the tree entry and its children.
+     * @return A set of {@link File files} in no particular order.
+     */
+    public abstract Set<? extends File> getFiles(String path, IRepoRevision<?> revision);
 
     @Override
     public abstract IMutableFileHistoryGraph getFileHistoryGraph();

--- a/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnRepositoryManager.java
+++ b/de.setsoftware.reviewtool.changesources.svn/src/de/setsoftware/reviewtool/changesources/svn/SvnRepositoryManager.java
@@ -132,6 +132,17 @@ final class SvnRepositoryManager {
     }
 
     /**
+     * Returns a reusable {@link SVNRepository} referring to a path in a remote repository.
+     * @param remoteRootUrl The root URL of the remote repository.
+     * @param path The path at the remote repository.
+     * @return A {@link SVNRepository} that refers to the specified path in the remote repository.
+     * @throws SVNException if an error occurs.
+     */
+    synchronized SVNRepository getTemporaryRepo(final SVNURL remoteRootUrl, final String path) throws SVNException {
+        return this.mgr.createRepository(remoteRootUrl.appendPath(path, false), true);
+    }
+
+    /**
      * Calls the given handler for all recent log entries of the given {@link SvnRepo}.
      * If there are revisions in the remote repository that have not been processed yet, they are loaded and processed
      * before being filtered.

--- a/de.setsoftware.reviewtool.core/META-INF/MANIFEST.MF
+++ b/de.setsoftware.reviewtool.core/META-INF/MANIFEST.MF
@@ -27,6 +27,7 @@ Bundle-ClassPath: target/lib/minimal-json-0.9.5.jar,
 Bundle-Activator: de.setsoftware.reviewtool.plugin.Activator
 Bundle-ActivationPolicy: lazy
 Export-Package: de.setsoftware.reviewtool.base,
+ de.setsoftware.reviewtool.base.tree,
  de.setsoftware.reviewtool.config,
  de.setsoftware.reviewtool.diffalgorithms,
  de.setsoftware.reviewtool.model,

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithms.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithms.java
@@ -51,9 +51,9 @@ public final class PartialOrderAlgorithms {
     }
 
     /**
-     * Returns all minimal elements of a partially ordered set.
-     * If the collection of revisions passed is empty, an empty list is returned.
-     * @param elements A partially ordered collection of elements where to find all minimal elements.
+     * Returns all minimal elements of a partially ordered collection.
+     * If the collection is empty, an empty list is returned.
+     * @param elements A partially ordered collection of elements.
      */
     public static <T extends IPartiallyComparable<T>, U extends T> List<U> getAllMinimalElements(
             final Collection<U> elements) {
@@ -77,9 +77,9 @@ public final class PartialOrderAlgorithms {
     }
 
     /**
-     * Returns all maximal elements of a partially ordered set.
-     * If the collection of revisions passed is empty, an empty list is returned.
-     * @param elements A partially ordered collection of elements where to find all maximal elements.
+     * Returns all maximal elements of a partially ordered collection.
+     * If the collection is empty, an empty list is returned.
+     * @param elements A partially ordered collection of elements.
      */
     public static <T extends IPartiallyComparable<T>, U extends T> List<U> getAllMaximalElements(
             final Collection<U> elements) {

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/AbstractTreeNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/AbstractTreeNode.java
@@ -1,0 +1,166 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Implements the common parts of the {@link TreeNode} interface.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <SelfT> The concrete type of the tree node.
+ */
+public abstract class AbstractTreeNode<K, V, SelfT extends TreeNode<K, V, SelfT>>
+        implements TreeNode<K, V, SelfT>, java.io.Serializable {
+
+    private static final long serialVersionUID = 3535612955038411471L;
+    private final SelfT parent;
+    private V value;
+
+    /**
+     * Constructor. Sets the node's value to some user-supplied value.
+     *
+     * @param parent The parent of the node or {@code null} if this is the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}.
+     */
+    protected AbstractTreeNode(final SelfT parent, final V value) {
+        this.parent = parent;
+        this.value = value;
+    }
+
+    @Override
+    public final SelfT getParent() {
+        return this.parent;
+    }
+
+    @Override
+    public final V getValue() {
+        return this.value;
+    }
+
+    @Override
+    public final V getValue(final K key) {
+        final SelfT result = this.getNode(key);
+        return result == null ? null : result.getValue();
+    }
+
+    @Override
+    public final V getValue(final List<K> path) {
+        final SelfT result = this.getNode(path);
+        return result == null ? null : result.getValue();
+    }
+
+    @Override
+    public final void setValue(final V value) {
+        this.value = value;
+    }
+
+    @Override
+    public final SelfT getNode(final List<K> path) {
+        SelfT current = this.getSelf();
+        final Iterator<K> it = path.iterator();
+        while (it.hasNext()) {
+            final K key = it.next();
+            final SelfT child = current.getNode(key);
+            if (child == null) {
+                return null;
+            } else {
+                current = child;
+            }
+        }
+        return current;
+    }
+
+    @Override
+    public final SelfT putValue(final List<K> path, final V value) {
+        SelfT current = this.getSelf();
+        final Iterator<K> it = path.iterator();
+        while (it.hasNext()) {
+            final K key = it.next();
+            SelfT child = current.getNode(key);
+            if (child == null) {
+                child = current.putValue(key, null);
+            }
+            current = child;
+        }
+        current.setValue(value);
+        return current;
+    }
+
+    @Override
+    public final List<V> getValues(final List<K> path) {
+        final List<V> result = new LinkedList<>();
+        SelfT current = this.getSelf();
+        final Iterator<K> it = path.iterator();
+        while (it.hasNext()) {
+            final SelfT child = current.getNode(it.next());
+            if (child == null) {
+                break;
+            } else {
+                if (current.getValue() != null) {
+                    result.add(0, current.getValue());
+                }
+                current = child;
+            }
+        }
+        if (current.getValue() != null) {
+            result.add(0, current.getValue());
+        }
+        return result;
+    }
+
+    @Override
+    public final V getNearestValue(final List<K> path) {
+        V lastKnownValue = null;
+        SelfT current = this.getSelf();
+        final Iterator<K> it = path.iterator();
+        while (it.hasNext()) {
+            final K key = it.next();
+            if (current.getValue() != null) {
+                lastKnownValue = current.getValue();
+            }
+
+            final SelfT child = current.getNode(key);
+            if (child == null) {
+                break;
+            } else {
+                current = child;
+            }
+        }
+        return current.getValue() != null ? current.getValue() : lastKnownValue;
+    }
+
+    @Override
+    public final int getHeight() {
+        int maxChildHeight = 0;
+        for (final Map.Entry<K, SelfT> entry : this.getEntries()) {
+            final int childHeight = entry.getValue().getHeight();
+            if (childHeight > maxChildHeight) {
+                maxChildHeight = childHeight;
+            }
+        }
+        return 1 + maxChildHeight;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof AbstractTreeNode<?, ?, ?>) {
+            final AbstractTreeNode<?, ?, ?> other = (AbstractTreeNode<?, ?, ?>) o;
+            return Objects.equals(this.value, other.value);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.value);
+    }
+
+    /**
+     * Returns this object cast to SelfT.
+     */
+    protected abstract SelfT getSelf();
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/DepthFirstTraversalTreeNodeIterator.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/DepthFirstTraversalTreeNodeIterator.java
@@ -1,0 +1,93 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Performs a depth-first traversal over a tree.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class DepthFirstTraversalTreeNodeIterator<K, V, N extends TreeNode<K, V, N>>
+        implements TreeNodeIterator<K, V, N> {
+
+    private final N root;
+    private final TreeChildOrderStrategy<K, V, N> childNodeStrategy;
+    private final TreeRootNodeStrategy<K, V, N> rootNodeStrategy;
+    private final Iterator<Pair<List<K>, N>> it;
+    private Iterator<Pair<List<K>, N>> nextLevelIt;
+
+    /**
+     * Constructor. Uses the empty path for the root node.
+     *
+     * @param root The root of the tree to traverse.
+     * @param rootNodeStrategy Specifies when the root node is visited during tree traversal.
+     * @param childNodeStrategy Specifies in which order the child nodes are visited during tree traversal.
+     */
+    public DepthFirstTraversalTreeNodeIterator(
+            final N root,
+            final TreeRootNodeStrategy<K, V, N> rootNodeStrategy,
+            final TreeChildOrderStrategy<K, V, N> childNodeStrategy) {
+
+        this(root, Collections.<K>emptyList(), rootNodeStrategy, childNodeStrategy);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param root The root of the tree to traverse.
+     * @param rootPath The path to the root of the tree.
+     * @param rootNodeStrategy Specifies when the root node is visited during tree traversal.
+     * @param childNodeStrategy Specifies in which order the child nodes are visited during tree traversal.
+     */
+    public DepthFirstTraversalTreeNodeIterator(
+            final N root,
+            final List<K> rootPath,
+            final TreeRootNodeStrategy<K, V, N> rootNodeStrategy,
+            final TreeChildOrderStrategy<K, V, N> childNodeStrategy) {
+
+        this.root = root;
+        this.childNodeStrategy = childNodeStrategy;
+        this.rootNodeStrategy = rootNodeStrategy;
+
+        final List<Pair<List<K>, N>> entries = new ArrayList<>();
+        for (final Map.Entry<K, N> entry : root.getEntries()) {
+            final List<K> childPath = new ArrayList<>(rootPath);
+            childPath.add(entry.getKey());
+            entries.add(Pair.create(childPath, entry.getValue()));
+        }
+        childNodeStrategy.finalizeNodeList(entries);
+        rootNodeStrategy.insertRootNode(entries, Pair.create(rootPath, root));
+        this.it = entries.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.nextLevelIt != null && this.nextLevelIt.hasNext() || this.it.hasNext();
+    }
+
+    @Override
+    public Pair<List<K>, N> next() {
+        assert this.hasNext();
+        if (this.nextLevelIt == null || !this.nextLevelIt.hasNext()) {
+            final Pair<List<K>, N> entry = this.it.next();
+            if (entry.getSecond() == this.root) {
+                return entry;
+            } else {
+                this.nextLevelIt = new DepthFirstTraversalTreeNodeIterator<>(
+                        entry.getSecond(),
+                        entry.getFirst(),
+                        this.rootNodeStrategy,
+                        this.childNodeStrategy);
+            }
+        }
+        return this.nextLevelIt.next();
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/FilteredTreeNodeIterator.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/FilteredTreeNodeIterator.java
@@ -1,0 +1,57 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Implements a node iterator on the top of another one that returns only nodes fulfilling a predicate.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class FilteredTreeNodeIterator<K, V, N extends TreeNode<K, V, N>> implements TreeNodeIterator<K, V, N> {
+
+    private final TreeNodeIterator<K, V, N> baseIt;
+    private final Predicate<N> predicate;
+    private Pair<List<K>, N> nextNode;
+
+    /**
+     * Constructor. Creates a tree node iterator that returns only nodes matching a given predicate.
+     *
+     * @param baseIt The base iterator.
+     * @param predicate The predicate filtering tree nodes.
+     */
+    public FilteredTreeNodeIterator(final TreeNodeIterator<K, V, N> baseIt, final Predicate<N> predicate) {
+        this.baseIt = baseIt;
+        this.predicate = predicate;
+        this.advance();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.nextNode != null;
+    }
+
+    @Override
+    public Pair<List<K>, N> next() {
+        final Pair<List<K>, N> result = this.nextNode;
+        this.advance();
+        return result;
+    }
+
+    /**
+     * Advances to next node that matches passed predicate.
+     */
+    private void advance() {
+        while (this.baseIt.hasNext()) {
+            this.nextNode = this.baseIt.next();
+            if (this.predicate.test(this.nextNode.getSecond())) {
+                return;
+            }
+        }
+        this.nextNode = null;
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/NonNullTreeNodePredicate.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/NonNullTreeNodePredicate.java
@@ -1,0 +1,18 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.function.Predicate;
+
+/**
+ * Matches tree nodes with a non-null value.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class NonNullTreeNodePredicate<K, V, N extends TreeNode<K, V, N>> implements Predicate<N> {
+
+    @Override
+    public boolean test(final N node) {
+        return node.getValue() != null;
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/OrderPreservingTreeNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/OrderPreservingTreeNode.java
@@ -1,0 +1,78 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * TreeNode implementation using unordered keys but preserving insertion order.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ */
+public final class OrderPreservingTreeNode<K extends Comparable<K>, V> extends
+        AbstractTreeNode<K, V, OrderPreservingTreeNode<K, V>> {
+
+    private static final long serialVersionUID = 168352569852009515L;
+    private final LinkedHashMap<K, OrderPreservingTreeNode<K, V>> children;
+
+    /**
+     * Constructor. Sets the node's value to some user-supplied value.
+     *
+     * @param parent The parent of the node or {@code null} if this is the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}.
+     */
+    private OrderPreservingTreeNode(final OrderPreservingTreeNode<K, V> parent, final V value) {
+        super(parent, value);
+        this.children = new LinkedHashMap<>();
+    }
+
+    /**
+     * Creates the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}.
+     */
+    public static <K extends Comparable<K>, V> OrderPreservingTreeNode<K, V> createRoot(final V value) {
+        return new OrderPreservingTreeNode<>(null, value);
+    }
+
+    @Override
+    public OrderPreservingTreeNode<K, V> getNode(final K key) {
+        return this.children.get(key);
+    }
+
+    @Override
+    public OrderPreservingTreeNode<K, V> putValue(final K key, final V value) {
+        OrderPreservingTreeNode<K, V> child = this.children.get(key);
+        if (child == null) {
+            child = new OrderPreservingTreeNode<>(this, value);
+            this.children.put(key, child);
+        } else {
+            child.setValue(value);
+        }
+        return child;
+    }
+
+    @Override
+    public Set<Map.Entry<K, OrderPreservingTreeNode<K, V>>> getEntries() {
+        return Collections.unmodifiableSet(this.children.entrySet());
+    }
+
+    @Override
+    public void removeNode(final OrderPreservingTreeNode<K, V> childNode) {
+        this.children.values().remove(childNode);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof OrderPreservingTreeNode<?, ?>) {
+            return super.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    protected OrderPreservingTreeNode<K, V> getSelf() {
+        return this;
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/OrderedTreeNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/OrderedTreeNode.java
@@ -1,0 +1,77 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * TreeNode implementation using {@link Comparable} keys.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ */
+public final class OrderedTreeNode<K extends Comparable<K>, V> extends AbstractTreeNode<K, V, OrderedTreeNode<K, V>> {
+
+    private static final long serialVersionUID = 8089192927259795001L;
+    private final TreeMap<K, OrderedTreeNode<K, V>> children;
+
+    /**
+     * Constructor. Sets the node's value to some user-supplied value.
+     *
+     * @param parent The parent of the node or {@code null} if this is the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}.
+     */
+    private OrderedTreeNode(final OrderedTreeNode<K, V> parent, final V value) {
+        super(parent, value);
+        this.children = new TreeMap<>();
+    }
+
+    /**
+     * Creates the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}.
+     */
+    public static <K extends Comparable<K>, V> OrderedTreeNode<K, V> createRoot(final V value) {
+        return new OrderedTreeNode<>(null, value);
+    }
+
+    @Override
+    public OrderedTreeNode<K, V> getNode(final K key) {
+        return this.children.get(key);
+    }
+
+    @Override
+    public OrderedTreeNode<K, V> putValue(final K key, final V value) {
+        OrderedTreeNode<K, V> child = this.children.get(key);
+        if (child == null) {
+            child = new OrderedTreeNode<>(this, value);
+            this.children.put(key, child);
+        } else {
+            child.setValue(value);
+        }
+        return child;
+    }
+
+    @Override
+    public Set<Map.Entry<K, OrderedTreeNode<K, V>>> getEntries() {
+        return Collections.unmodifiableSet(this.children.entrySet());
+    }
+
+    @Override
+    public void removeNode(final OrderedTreeNode<K, V> childNode) {
+        this.children.values().remove(childNode);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof OrderedTreeNode<?, ?>) {
+            return super.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    protected OrderedTreeNode<K, V> getSelf() {
+        return this;
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeChildOrderStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeChildOrderStrategy.java
@@ -1,0 +1,22 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Specifies in which order the child nodes are visited during tree traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public interface TreeChildOrderStrategy<K, V, N extends TreeNode<K, V, N>> {
+
+    /**
+     * Finalizes the order of the tree nodes to be visited by the tree iterator.
+     *
+     * @param nodeList The list of nodes the tree iterator will visit.
+     */
+    public abstract void finalizeNodeList(List<Pair<List<K>, N>> nodeList);
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeInOrderRootNodeStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeInOrderRootNodeStrategy.java
@@ -1,0 +1,33 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Implements in-order tree traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class TreeInOrderRootNodeStrategy<K, V, N extends TreeNode<K, V, N>>
+        implements TreeRootNodeStrategy<K, V, N> {
+
+    private final int index;
+
+    /**
+     * Constructor.
+     *
+     * @param index The index at which to insert the root node.
+     */
+    public TreeInOrderRootNodeStrategy(final int index) {
+        this.index = index;
+    }
+
+    @Override
+    public void insertRootNode(final List<Pair<List<K>, N>> nodeList,
+            final Pair<List<K>, N> rootEntry) {
+        nodeList.add(this.index, rootEntry);
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeLeftToRightChildOrderStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeLeftToRightChildOrderStrategy.java
@@ -1,0 +1,20 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Implements left-to-right child node traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class TreeLeftToRightChildOrderStrategy<K, V, N extends TreeNode<K, V, N>>
+        implements TreeChildOrderStrategy<K, V, N> {
+
+    @Override
+    public void finalizeNodeList(final List<Pair<List<K>, N>> nodeList) {
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeNode.java
@@ -1,0 +1,124 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A tree (node) represented as a map of maps. The number of children of a node is not fixed. Each node is the potential
+ * root node of a (sub)tree.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <SelfT> The concrete type of the tree node.
+ */
+public interface TreeNode<K, V, SelfT extends TreeNode<K, V, SelfT>> {
+
+    /**
+     * Returns the parent node or {@code null} if this is the root node of the tree.
+     */
+    public abstract SelfT getParent();
+
+    /**
+     * Returns the value of this node.
+     *
+     * @return The value of this node or {@code null} if not set.
+     */
+    public abstract V getValue();
+
+    /**
+     * Returns the value of a direct child node given its key.
+     * Note that the caller cannot distinguish a missing node from an existing node without a value.
+     *
+     * @param key The key.
+     * @return The node's value or {@code null} if no node exists for the given key.
+     */
+    public abstract V getValue(final K key);
+
+    /**
+     * Returns the value of a node given a path of keys. If the path is empty, {@code this.getValue()} is returned.
+     * Note that the caller cannot distinguish a missing node from an existing node without a value.
+     *
+     * @param path The path of keys.
+     * @return The node's value or {@code null} if no node can be reached using the given path.
+     */
+    public abstract V getValue(final List<K> path);
+
+    /**
+     * Sets the value of this node.
+     *
+     * @param value The new value of this node.
+     */
+    public abstract void setValue(V value);
+
+    /**
+     * Returns a direct child node given its key.
+     *
+     * @param key The key.
+     * @return The node or {@code null} if no node exists for the given key.
+     */
+    public abstract SelfT getNode(K key);
+
+    /**
+     * Returns a node given a path of keys. If the path is empty, {@code this} is returned.
+     *
+     * @param path The path of keys.
+     * @return The node or {@code null} if no node can be reached using the given path.
+     */
+    public abstract SelfT getNode(List<K> path);
+
+    /**
+     * Sets the value of a direct child node given its key. If the node does not exist yet, it is created.
+     *
+     * @param key The key.
+     * @param value The value to put. May be {@code null}.
+     * @return The child node.
+     */
+    public abstract SelfT putValue(K key, V value);
+
+    /**
+     * Sets the value of the node at the position specified by a path of keys. The node and all intermediate nodes
+     * are created if necessary (the latter with a {@code null} value). The empty path is allowed.
+     *
+     * @param path The path of keys.
+     * @param value The value to put.
+     * @return The node having its value set.
+     */
+    public abstract SelfT putValue(List<K> path, V value);
+
+    /**
+     * Returns all direct children of this node together with their keys. The set returned is unmodifiable.
+     */
+    public abstract Set<Map.Entry<K, SelfT>> getEntries();
+
+    /**
+     * Returns all non-{@code null} values on the way from the selected node to the root, given a path of keys.
+     *
+     * @param path The path of keys.
+     * @return The non-{@code null} values on the way from the selected node to the root. The list is empty iff no node
+     *         on the path has a non-{@code null} value.
+     */
+    public abstract List<V> getValues(List<K> path);
+
+    /**
+     * Returns the last non-null value on a node path. If the path is empty, {@code this.getValue()} is returned.
+     * The tree traversal stops at the first non-existing node.
+     *
+     * @param path The path of keys.
+     * @return The value or {@code null} if there are no non-{@code null} values on the path.
+     */
+    public abstract V getNearestValue(List<K> path);
+
+    /**
+     * Computes the height of the tree starting at this node.
+     *
+     * @return The tree height.
+     */
+    public abstract int getHeight();
+
+    /**
+     * Removes a child node from this node.
+     * @param childNode The child node to delete.
+     */
+    public abstract void removeNode(final SelfT childNode);
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeNodeIterator.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeNodeIterator.java
@@ -1,0 +1,17 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.Iterator;
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Represents an iterator over a tree.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public interface TreeNodeIterator<K, V, N extends TreeNode<K, V, N>> extends Iterator<Pair<List<K>, N>> {
+
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreePostOrderRootNodeStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreePostOrderRootNodeStrategy.java
@@ -1,0 +1,23 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Implements post-order tree traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class TreePostOrderRootNodeStrategy<K, V, N extends TreeNode<K, V, N>>
+        implements TreeRootNodeStrategy<K, V, N> {
+
+    @Override
+    public void insertRootNode(
+            final List<Pair<List<K>, N>> nodeList,
+            final Pair<List<K>, N> rootEntry) {
+        nodeList.add(rootEntry);
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreePreOrderRootNodeStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreePreOrderRootNodeStrategy.java
@@ -1,0 +1,22 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Implements pre-order tree traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class TreePreOrderRootNodeStrategy<K, V, N extends TreeNode<K, V, N>>
+        implements TreeRootNodeStrategy<K, V, N> {
+
+    @Override
+    public void insertRootNode(final List<Pair<List<K>, N>> nodeList,
+            final Pair<List<K>, N> rootEntry) {
+        nodeList.add(0, rootEntry);
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeRightToLeftChildOrderStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeRightToLeftChildOrderStrategy.java
@@ -1,0 +1,22 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.Collections;
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Implements right-to-left child node traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public final class TreeRightToLeftChildOrderStrategy<K, V, N extends TreeNode<K, V, N>>
+        implements TreeChildOrderStrategy<K, V, N> {
+
+    @Override
+    public void finalizeNodeList(final List<Pair<List<K>, N>> nodeList) {
+        Collections.reverse(nodeList);
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeRootNodeStrategy.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/TreeRootNodeStrategy.java
@@ -1,0 +1,24 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.List;
+
+import de.setsoftware.reviewtool.base.Pair;
+
+/**
+ * Specifies when the root node is visited during tree traversal.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ * @param <N> The concrete type of the tree node.
+ */
+public interface TreeRootNodeStrategy<K, V, N extends TreeNode<K, V, N>> {
+
+    /**
+     * Inserts the root node into the node list.
+     *
+     * @param nodeList The list of nodes the tree iterator will visit.
+     * @param rootEntry The root entry to be inserted into the node list.
+     */
+    public abstract void insertRootNode(List<Pair<List<K>, N>> nodeList, Pair<List<K>, N> rootEntry);
+
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/UnorderedTreeNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/base/tree/UnorderedTreeNode.java
@@ -1,0 +1,77 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * TreeNode implementation using unordered keys.
+ *
+ * @param <K> The type of the keys in the tree.
+ * @param <V> The type of the values in the tree.
+ */
+public final class UnorderedTreeNode<K, V> extends AbstractTreeNode<K, V, UnorderedTreeNode<K, V>> {
+
+    private static final long serialVersionUID = -1870841040919574919L;
+    private final HashMap<K, UnorderedTreeNode<K, V>> children;
+
+    /**
+     * Constructor. Sets the node's value to some user-supplied value.
+     *
+     * @param parent The parent of the node or {@code null} if this is the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}
+     */
+    private UnorderedTreeNode(final UnorderedTreeNode<K, V> parent, final V value) {
+        super(parent, value);
+        this.children = new HashMap<>();
+    }
+
+    /**
+     * Creates the root node of the tree.
+     * @param value The initial value of the node. May be {@code null}.
+     */
+    public static <K, V> UnorderedTreeNode<K, V> createRoot(final V value) {
+        return new UnorderedTreeNode<>(null, value);
+    }
+
+    @Override
+    public UnorderedTreeNode<K, V> getNode(final K key) {
+        return this.children.get(key);
+    }
+
+    @Override
+    public UnorderedTreeNode<K, V> putValue(final K key, final V value) {
+        UnorderedTreeNode<K, V> child = this.children.get(key);
+        if (child == null) {
+            child = new UnorderedTreeNode<>(this, value);
+            this.children.put(key, child);
+        } else {
+            child.setValue(value);
+        }
+        return child;
+    }
+
+    @Override
+    public Set<Map.Entry<K, UnorderedTreeNode<K, V>>> getEntries() {
+        return Collections.unmodifiableSet(this.children.entrySet());
+    }
+
+    @Override
+    public void removeNode(final UnorderedTreeNode<K, V> childNode) {
+        this.children.values().remove(childNode);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof UnorderedTreeNode<?, ?>) {
+            return super.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    protected UnorderedTreeNode<K, V> getSelf() {
+        return this;
+    }
+}

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IFileHistoryGraph.java
@@ -23,7 +23,7 @@ public interface IFileHistoryGraph {
     public abstract IFileHistoryNode getNodeFor(IRevisionedFile file);
 
     /**
-     * Returns the nearest ancestors for passed {@link IRevisionedFile} having the same path, or <code>null</code>
+     * Returns the nearest ancestors for passed {@link IRevisionedFile} having the same path, or an empty set
      * if no suitable nodes exist. To be suitable, the ancestor node must not be deleted.
      */
     public abstract Set<? extends IFileHistoryNode> findAncestorsFor(IRevisionedFile file);

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
@@ -37,24 +37,6 @@ public interface IMutableFileHistoryGraph extends IFileHistoryGraph, Serializabl
             IRevision revision);
 
     /**
-     * Adds the information that the path {@code path} was replaced by a fresh path (file or directory) in revision
-     * {@code revision}.
-     */
-    public abstract void addReplacement(
-            String path,
-            IRevision revision);
-
-    /**
-     * Adds the information that the path {@code path} was replaced by a fresh path (file or directory) in revision
-     * {@code revision}, copied from {@code pathFrom} at revision {@code revisionFrom}.
-     */
-    public abstract void addReplacement(
-            String path,
-            IRevision revision,
-            String pathFrom,
-            IRevision revisionFrom);
-
-    /**
      * Adds the information that the path {@code pathFrom} at revision {@code revisionFrom} was copied to
      * path {@code pathTo} in revision {@code revisionTo}.
      */
@@ -63,5 +45,4 @@ public interface IMutableFileHistoryGraph extends IFileHistoryGraph, Serializabl
             String pathTo,
             IRevision revisionFrom,
             IRevision revisionTo);
-
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/api/IMutableFileHistoryGraph.java
@@ -42,7 +42,7 @@ public interface IMutableFileHistoryGraph extends IFileHistoryGraph, Serializabl
      */
     public abstract void addCopy(
             String pathFrom,
-            String pathTo,
             IRevision revisionFrom,
+            String pathTo,
             IRevision revisionTo);
 }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryEdge.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryEdge.java
@@ -92,7 +92,7 @@ public final class FileHistoryEdge extends ProxyableFileHistoryEdge {
 
     @Override
     public int hashCode() {
-        return this.ancestor.hashCode() ^ this.descendant.hashCode() ^ this.type.hashCode();
+        return this.ancestor.hashCode() ^ this.descendant.hashCode();
     }
 
     /**
@@ -131,7 +131,7 @@ public final class FileHistoryEdge extends ProxyableFileHistoryEdge {
         }
     }
 
-    private String guessEncoding(byte[] oldFileContent, byte[] newFileContent) {
+    private String guessEncoding(final byte[] oldFileContent, final byte[] newFileContent) {
         if (this.isValidUtf8(oldFileContent) && this.isValidUtf8(newFileContent)) {
             return "UTF-8";
         } else {
@@ -142,7 +142,7 @@ public final class FileHistoryEdge extends ProxyableFileHistoryEdge {
     /**
      * Returns true iff the given bytes are syntactically valid UTF-8.
      */
-    private boolean isValidUtf8(byte[] content) {
+    private boolean isValidUtf8(final byte[] content) {
         try {
             StandardCharsets.UTF_8.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
@@ -52,7 +52,10 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
             final IRevision revision) {
 
         final IRevisionedFile file = ChangestructureFactory.createFileInRevision(path, revision);
-        this.getOrCreateConnectedNode(file, IFileHistoryNode.Type.ADDED);
+        final ProxyableFileHistoryNode node = this.getOrCreateConnectedNode(file, IFileHistoryNode.Type.ADDED);
+        if (node.getType().equals(IFileHistoryNode.Type.DELETED)) {
+            node.makeReplaced();
+        }
     }
 
     @Override
@@ -97,47 +100,21 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
     }
 
     @Override
-    public final void addReplacement(
-            final String path,
-            final IRevision revision) {
-
-        this.addDeletion(path, revision);
-        this.addAddition(path, revision);
-    }
-
-    @Override
-    public final void addReplacement(
-            final String path,
-            final IRevision revision,
-            final String pathFrom,
-            final IRevision revisionFrom) {
-
-        this.addDeletion(path, revision);
-        this.addCopy(pathFrom, path, revisionFrom, revision, IFileHistoryNode.Type.ADDED);
-    }
-
-    @Override
     public final void addCopy(
             final String pathFrom,
             final String pathTo,
             final IRevision revisionFrom,
             final IRevision revisionTo) {
-        this.addCopy(pathFrom, pathTo, revisionFrom, revisionTo, IFileHistoryNode.Type.CHANGED);
-    }
-
-    private void addCopy(
-            final String pathFrom,
-            final String pathTo,
-            final IRevision revisionFrom,
-            final IRevision revisionTo,
-            final IFileHistoryNode.Type nodeType) {
 
         final IRevisionedFile fileFrom = ChangestructureFactory.createFileInRevision(pathFrom, revisionFrom);
         final IRevisionedFile fileTo = ChangestructureFactory.createFileInRevision(pathTo, revisionTo);
 
         final ProxyableFileHistoryNode fromNode =
                 this.getOrCreateConnectedNode(fileFrom, IFileHistoryNode.Type.UNCONFIRMED);
-        final ProxyableFileHistoryNode toNode = this.getOrCreateUnconnectedNode(fileTo, nodeType);
+        final ProxyableFileHistoryNode toNode = this.getOrCreateUnconnectedNode(fileTo, IFileHistoryNode.Type.CHANGED);
+        if (toNode.getType().equals(IFileHistoryNode.Type.DELETED)) {
+            toNode.makeReplaced();
+        }
 
         this.createMissingChildren(fromNode);
 
@@ -430,10 +407,6 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
                 if (!ancestors.isEmpty()) {
                     this.addNodeWithAncestors(node, ancestors, IFileHistoryEdge.Type.NORMAL);
                 }
-            }
-        } else {
-            if (nodeType.equals(IFileHistoryNode.Type.ADDED)) {
-                node.makeReplaced();
             }
         }
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraph.java
@@ -102,8 +102,8 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
     @Override
     public final void addCopy(
             final String pathFrom,
-            final String pathTo,
             final IRevision revisionFrom,
+            final String pathTo,
             final IRevision revisionTo) {
 
         final IRevisionedFile fileFrom = ChangestructureFactory.createFileInRevision(pathFrom, revisionFrom);
@@ -161,8 +161,8 @@ public final class FileHistoryGraph extends AbstractFileHistoryGraph implements 
                 final String childPath = child.getFile().getPath();
                 this.addCopy(
                         childPath,
-                        toParentPath.concat(childPath.substring(fromParentPath.length())),
                         fromRevision,
+                        toParentPath.concat(childPath.substring(fromParentPath.length())),
                         toRevision);
             }
         }

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryNode.java
@@ -133,7 +133,7 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
 
     @Override
     public int hashCode() {
-        return this.file.hashCode() ^ this.type.hashCode();
+        return this.file.hashCode();
     }
 
     @Override

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryNode.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryNode.java
@@ -155,7 +155,7 @@ public final class FileHistoryNode extends ProxyableFileHistoryNode {
 
     @Override
     void makeDeleted() {
-        assert this.type.equals(Type.ADDED) || this.type.equals(Type.CHANGED);
+        assert !this.type.equals(Type.UNCONFIRMED) && !this.type.equals(Type.DELETED);
         this.type = Type.DELETED;
 
         final Iterator<ProxyableFileHistoryEdge> it = this.ancestors.iterator();

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraph.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraph.java
@@ -160,7 +160,7 @@ public final class VirtualFileHistoryGraph extends AbstractFileHistoryGraph {
             }
             return ancestors;
         } else {
-            return null;
+            return new LinkedHashSet<>();
         }
     }
 

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithmsTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/PartialOrderAlgorithmsTest.java
@@ -32,6 +32,25 @@ public class PartialOrderAlgorithmsTest {
         public boolean le(final MyNumber other) {
             return other.value % this.value == 0;
         }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (obj instanceof MyNumber) {
+                final MyNumber o = (MyNumber) obj;
+                return this.value == o.value;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(this.value);
+        }
     }
 
     @Test

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/OrderPreservingTreeNodeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/OrderPreservingTreeNodeTest.java
@@ -1,0 +1,12 @@
+package de.setsoftware.reviewtool.base.tree;
+
+/**
+ * Tests {@link UnorderedTreeNode}.
+ */
+public final class OrderPreservingTreeNodeTest extends TreeNodeTest {
+
+    @Override
+    protected <K extends Comparable<K>, V> OrderPreservingTreeNode<K, V> createNode(final V value) {
+        return OrderPreservingTreeNode.createRoot(value);
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/OrderedTreeNodeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/OrderedTreeNodeTest.java
@@ -1,0 +1,12 @@
+package de.setsoftware.reviewtool.base.tree;
+
+/**
+ * Tests {@link OrderedTreeNode}.
+ */
+public final class OrderedTreeNodeTest extends TreeNodeTest {
+
+    @Override
+    protected <K extends Comparable<K>, V> OrderedTreeNode<K, V> createNode(final V value) {
+        return OrderedTreeNode.createRoot(value);
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/TreeNodeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/TreeNodeTest.java
@@ -1,0 +1,296 @@
+package de.setsoftware.reviewtool.base.tree;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link OrderedTreeNode}.
+ */
+public abstract class TreeNodeTest {
+
+    private TreeNode<String, Integer, ?> root;
+    private TreeNode<String, Integer, ?> childA;
+    private TreeNode<String, Integer, ?> childB;
+    private TreeNode<String, Integer, ?> childAA;
+    private TreeNode<String, Integer, ?> childBB;
+
+    /**
+     * Creates a node with an initial value.
+     * @param value The initial value.
+     */
+    protected abstract <K extends Comparable<K>, V> TreeNode<K, V, ?> createNode(V value);
+
+    /**
+     * Creates an initial tree.
+     */
+    @Before
+    public void setUp() {
+        this.root = this.createNode(null);
+        this.childA = this.root.putValue("a", 1);
+        this.childB = this.root.putValue("b", 2);
+        this.childAA = this.childA.putValue("aa", 11);
+        this.childBB = this.childB.putValue("bb", 22);
+    }
+
+    /**
+     * Tests {@link TreeNode#getParent()}.
+     */
+    @Test
+    public void testGetParent() {
+        assertSame(this.root, this.childA.getParent());
+        assertSame(this.root, this.childB.getParent());
+        assertSame(this.childA, this.childAA.getParent());
+        assertSame(this.childB, this.childBB.getParent());
+    }
+
+    /**
+     * Tests {@link TreeNode#getValue()}.
+     */
+    @Test
+    public void testGetValue() {
+        assertNull(this.root.getValue());
+        assertSame(Integer.valueOf(1), this.childA.getValue());
+        assertSame(Integer.valueOf(2), this.childB.getValue());
+        assertSame(Integer.valueOf(11), this.childAA.getValue());
+        assertSame(Integer.valueOf(22), this.childBB.getValue());
+    }
+
+    /**
+     * Tests {@link TreeNode#getValue(Object)}.
+     */
+    @Test
+    public void testGetValueByKey() {
+        assertNull(this.root.getValue());
+        assertSame(Integer.valueOf(1), this.root.getValue("a"));
+        assertSame(Integer.valueOf(2), this.root.getValue("b"));
+        assertSame(Integer.valueOf(11), this.childA.getValue("aa"));
+        assertSame(Integer.valueOf(22), this.childB.getValue("bb"));
+        assertNull(this.root.getValue("c"));
+    }
+
+    /**
+     * Tests {@link TreeNode#getValue(java.util.List)}.
+     */
+    @Test
+    public void testGetValueByPath() {
+        final TreeNode<String, Integer, ?> newRoot = this.createNode(null);
+        final TreeNode<String, Integer, ?> newChildA = newRoot.putValue("a", null);
+        final TreeNode<String, Integer, ?> newChildB = newRoot.putValue("b", 2);
+        final TreeNode<String, Integer, ?> newChildAA = newChildA.putValue("aa", 11);
+        final TreeNode<String, Integer, ?> newChildBB = newChildB.putValue("bb", null);
+        final TreeNode<String, Integer, ?> newChildAAA = newChildAA.putValue("aaa", null);
+        final TreeNode<String, Integer, ?> newChildBBB = newChildBB.putValue("bbb", 222);
+
+        assertNull(newRoot.getValue(Collections.singletonList("a")));
+        assertSame(newChildB.getValue(), newRoot.getValue(Collections.singletonList("b")));
+        assertNull(newRoot.getValue(Collections.singletonList("c")));
+        assertSame(newChildAA.getValue(), newRoot.getValue(Arrays.asList("a", "aa")));
+        assertSame(newChildBB.getValue(), newRoot.getValue(Arrays.asList("b", "bb")));
+        assertNull(newRoot.getValue(Arrays.asList("a", "ab")));
+        assertNull(newRoot.getValue(Arrays.asList("b", "bc")));
+        assertSame(newChildAAA.getValue(), newRoot.getValue(Arrays.asList("a", "aa", "aaa")));
+        assertNull(newRoot.getValue(Arrays.asList("a", "aa", "aab")));
+        assertSame(newChildBBB.getValue(), newRoot.getValue(Arrays.asList("b", "bb", "bbb")));
+        assertNull(newRoot.getValue(Arrays.asList("b", "bb", "bbc")));
+        assertNull(newRoot.getValue(Arrays.asList()));
+    }
+
+    /**
+     * Tests {@link TreeNode#setValue(Object)}.
+     */
+    @Test
+    public void testSetValue() {
+        this.root.setValue(0);
+        assertEquals(Integer.valueOf(0), this.root.getValue());
+        this.childA.setValue(4);
+        assertEquals(Integer.valueOf(4), this.childA.getValue());
+    }
+
+    /**
+     * Tests {@link TreeNode#getNode(Object)}.
+     */
+    @Test
+    public void testGetNode() {
+        TreeNode<String, Integer, ?> node = this.root.getNode("a");
+        assertSame(this.childA, node);
+        node = this.root.getNode("b");
+        assertSame(this.childB, node);
+        node = this.root.getNode("a").getNode("aa");
+        assertSame(this.childAA, node);
+        node = this.root.getNode("b").getNode("bb");
+        assertSame(this.childBB, node);
+        node = this.root.getNode("c");
+        assertNull(node);
+    }
+
+    /**
+     * Tests {@link TreeNode#getNode(java.util.List)}.
+     */
+    @Test
+    public void testGetNodeByPath() {
+        TreeNode<String, Integer, ?> node = this.root.getNode(Arrays.asList("a"));
+        assertSame(this.childA, node);
+        node = this.root.getNode(Arrays.asList("b"));
+        assertSame(this.childB, node);
+        node = this.root.getNode(Arrays.asList("a", "aa"));
+        assertSame(this.childAA, node);
+        node = this.root.getNode(Arrays.asList("b", "bb"));
+        assertSame(this.childBB, node);
+        node = this.root.getNode(Arrays.asList("c"));
+        assertNull(node);
+    }
+
+    /**
+     * Tests {@link TreeNode#putValue(Object, Object)}.
+     */
+    @Test
+    public void testPutValue() {
+        final TreeNode<String, Integer, ?> node = this.root.putValue("a", 3);
+        assertSame(node, this.childA);
+        assertEquals(Integer.valueOf(3), node.getValue());
+    }
+
+    /**
+     * Tests {@link TreeNode#putValue(java.util.List, Object)} (all intermediate nodes are available).
+     */
+    @Test
+    public void testPutValueByPath1() {
+        final TreeNode<String, Integer, ?> newRoot = this.createNode(null);
+        final TreeNode<String, Integer, ?> newChildA =
+                newRoot.putValue(Collections.singletonList("a"), this.childA.getValue());
+        final TreeNode<String, Integer, ?> newChildB =
+                newRoot.putValue(Collections.singletonList("b"), this.childB.getValue());
+        final TreeNode<String, Integer, ?> newChildAA =
+                newRoot.putValue(Arrays.asList("a", "aa"), this.childAA.getValue());
+        final TreeNode<String, Integer, ?> newChildBB =
+                newRoot.putValue(Arrays.asList("b", "bb"), this.childBB.getValue());
+
+        assertEquals(this.root, newRoot);
+        assertEquals(this.childA, newChildA);
+        assertEquals(this.childB, newChildB);
+        assertEquals(this.childAA, newChildAA);
+        assertEquals(this.childBB, newChildBB);
+    }
+
+    /**
+     * Tests {@link TreeNode#putValue(java.util.List, Object)} (some intermediate nodes are missing).
+     */
+    @Test
+    public void testPutValueByPath2() {
+        final TreeNode<String, Integer, ?> newRoot = this.createNode(null);
+        final TreeNode<String, Integer, ?> newChildAA =
+                newRoot.putValue(Arrays.asList("a", "aa"), this.childAA.getValue());
+        final TreeNode<String, Integer, ?> newChildBB =
+                newRoot.putValue(Arrays.asList("b", "bb"), this.childBB.getValue());
+        final TreeNode<String, Integer, ?> newChildA = newRoot.getNode("a");
+        newChildA.setValue(this.childA.getValue());
+        final TreeNode<String, Integer, ?> newChildB = newRoot.getNode("b");
+        newChildB.setValue(this.childB.getValue());
+
+        assertEquals(this.root, newRoot);
+        assertEquals(this.childA, newChildA);
+        assertEquals(this.childB, newChildB);
+        assertEquals(this.childAA, newChildAA);
+        assertEquals(this.childBB, newChildBB);
+    }
+
+    /**
+     * Tests {@link TreeNode#getEntries()}.
+     */
+    @Test
+    public void testGetEntries() {
+        final Map<String, TreeNode<String, Integer, ?>> expectedRootEntries = new HashMap<>();
+        expectedRootEntries.put("a", this.childA);
+        expectedRootEntries.put("b", this.childB);
+        assertEquals(expectedRootEntries.entrySet(), this.root.getEntries());
+
+        final Map<String, TreeNode<String, Integer, ?>> expectedAEntries = new HashMap<>();
+        expectedAEntries.put("aa", this.childAA);
+        assertEquals(expectedAEntries.entrySet(), this.childA.getEntries());
+
+        final Map<String, TreeNode<String, Integer, ?>> expectedBEntries = new HashMap<>();
+        expectedBEntries.put("bb", this.childBB);
+        assertEquals(expectedBEntries.entrySet(), this.childB.getEntries());
+
+        assertEquals(new HashMap<>().entrySet(), this.childAA.getEntries());
+        assertEquals(new HashMap<>().entrySet(), this.childBB.getEntries());
+    }
+
+    /**
+     * Tests {@link TreeNode#getValues(java.util.List)}.
+     */
+    @Test
+    public void testGetValues() {
+        assertEquals(Arrays.asList(11, 1), this.root.getValues(Arrays.asList("a", "aa")));
+        assertEquals(Arrays.asList(22, 2), this.root.getValues(Arrays.asList("b", "bb")));
+
+        assertEquals(Arrays.asList(1), this.root.getValues(Arrays.asList("a", "x")));
+        assertEquals(Arrays.asList(2), this.root.getValues(Arrays.asList("b", "y")));
+
+        this.root.setValue(0);
+        assertEquals(Arrays.asList(11, 1, 0), this.root.getValues(Arrays.asList("a", "aa")));
+        assertEquals(Arrays.asList(22, 2, 0), this.root.getValues(Arrays.asList("b", "bb")));
+
+        this.childA.setValue(null);
+        this.childB.setValue(null);
+        assertEquals(Arrays.asList(11, 0), this.root.getValues(Arrays.asList("a", "aa")));
+        assertEquals(Arrays.asList(22, 0), this.root.getValues(Arrays.asList("b", "bb")));
+
+        this.childAA.setValue(null);
+        this.childBB.setValue(null);
+        assertEquals(Arrays.asList(0), this.root.getValues(Arrays.asList("a", "aa")));
+        assertEquals(Arrays.asList(0), this.root.getValues(Arrays.asList("b", "bb")));
+
+        this.root.setValue(null);
+        assertEquals(Collections.emptyList(), this.root.getValues(Arrays.asList("a", "aa")));
+        assertEquals(Collections.emptyList(), this.root.getValues(Arrays.asList("b", "bb")));
+    }
+
+    /**
+     * Tests {@link TreeNode#getNearestValue(java.util.List)}.
+     */
+    @Test
+    public void testGetDeepestNode() {
+        final TreeNode<String, Integer, ?> newRoot = this.createNode(null);
+        final TreeNode<String, Integer, ?> newChildA = newRoot.putValue("a", null);
+        final TreeNode<String, Integer, ?> newChildB = newRoot.putValue("b", 2);
+        final TreeNode<String, Integer, ?> newChildAA = newChildA.putValue("aa", 11);
+        final TreeNode<String, Integer, ?> newChildBB = newChildB.putValue("bb", null);
+        newChildAA.putValue("aaa", null);
+        final TreeNode<String, Integer, ?> newChildBBB = newChildBB.putValue("bbb", 222);
+
+        assertNull(newRoot.getNearestValue(Collections.singletonList("a")));
+        assertSame(newChildB.getValue(), newRoot.getNearestValue(Collections.singletonList("b")));
+        assertNull(newRoot.getNearestValue(Collections.singletonList("c")));
+        assertSame(newChildAA.getValue(), newRoot.getNearestValue(Arrays.asList("a", "aa")));
+        assertSame(newChildB.getValue(), newRoot.getNearestValue(Arrays.asList("b", "bb")));
+        assertNull(newRoot.getNearestValue(Arrays.asList("a", "ab")));
+        assertSame(newChildB.getValue(), newRoot.getNearestValue(Arrays.asList("b", "bc")));
+        assertSame(newChildAA.getValue(), newRoot.getNearestValue(Arrays.asList("a", "aa", "aaa")));
+        assertSame(newChildAA.getValue(), newRoot.getNearestValue(Arrays.asList("a", "aa", "aab")));
+        assertSame(newChildBBB.getValue(), newRoot.getNearestValue(Arrays.asList("b", "bb", "bbb")));
+        assertSame(newChildB.getValue(), newRoot.getNearestValue(Arrays.asList("b", "bb", "bbc")));
+        assertNull(newRoot.getNearestValue(Arrays.asList()));
+    }
+
+    /**
+     * Tests {@link TreeNode#getHeight()}.
+     */
+    @Test
+    public void testGetHeight() {
+        assertEquals(3, this.root.getHeight());
+        assertEquals(2, this.childA.getHeight());
+        assertEquals(2, this.childB.getHeight());
+        assertEquals(1, this.childAA.getHeight());
+        assertEquals(1, this.childBB.getHeight());
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/UnorderedTreeNodeTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/base/tree/UnorderedTreeNodeTest.java
@@ -1,0 +1,12 @@
+package de.setsoftware.reviewtool.base.tree;
+
+/**
+ * Tests {@link UnorderedTreeNode}.
+ */
+public final class UnorderedTreeNodeTest extends TreeNodeTest {
+
+    @Override
+    protected <K extends Comparable<K>, V> UnorderedTreeNode<K, V> createNode(final V value) {
+        return UnorderedTreeNode.createRoot(value);
+    }
+}

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphGetLatestFilesTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphGetLatestFilesTest.java
@@ -47,7 +47,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testCopy() {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         assertEquals(
                 Arrays.asList(file("a", 5), file("b", 6)),
                 g.getLatestFiles(file("a", 1), false));
@@ -85,7 +85,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testMoveOneWay() {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         g.addDeletion("a", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6)),
@@ -103,7 +103,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addDeletion("a", rev(6));
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6)),
                 g.getLatestFiles(file("a", 1), false));
@@ -119,10 +119,10 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testMoveWithMultipleCopies() {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)) );
-        g.addCopy("a", "b", rev(5), rev(6));
+        g.addCopy("a", rev(5), "b", rev(6));
         g.addDeletion("a", rev(6));
-        g.addCopy("a", "c", rev(5), rev(6));
-        g.addCopy("a", "d", rev(5), rev(6));
+        g.addCopy("a", rev(5), "c", rev(6));
+        g.addCopy("a", rev(5), "d", rev(6));
         assertEquals(
                 Arrays.asList(file("b", 6), file("c", 6), file("d", 6)),
                 g.getLatestFiles(file("a", 1), false));
@@ -145,11 +145,11 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addDeletion("a", rev(11));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addDeletion("b", rev(21));
-        g.addCopy("b", "c", rev(20), rev(21));
+        g.addCopy("b", rev(20), "c", rev(21));
         g.addDeletion("c", rev(31));
-        g.addCopy("c", "d", rev(30), rev(31));
+        g.addCopy("c", rev(30), "d", rev(31));
 
         assertEquals(
                 Arrays.asList(file("d", 31)),
@@ -167,7 +167,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addDeletion("a", rev(11));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addDeletion("b", rev(21));
 
         assertEquals(
@@ -182,7 +182,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testMoveAndDeleteAfterwardsStartWithDeletion() {
         final IMutableFileHistoryGraph g = graph();
         g.addDeletion("a", rev(11));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addDeletion("b", rev(21));
 
         assertEquals(
@@ -199,7 +199,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addChange("a", rev(6), Collections.singleton(rev(5)));
         g.addDeletion("a", rev(20));
-        g.addCopy("a", "b", rev(5), rev(23));
+        g.addCopy("a", rev(5), "b", rev(23));
         assertEquals(
                 Arrays.asList(file("b", 23)),
                 g.getLatestFiles(file("a", 1), false));
@@ -218,7 +218,7 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testCopyWithRevisionSkipStartWithDeletion() {
         final IMutableFileHistoryGraph g = graph();
         g.addDeletion("a", rev(20));
-        g.addCopy("a", "b", rev(5), rev(23));
+        g.addCopy("a", rev(5), "b", rev(23));
         assertEquals(
                 Arrays.asList(file("a", 1)),
                 g.getLatestFiles(file("a", 1), false));
@@ -242,8 +242,8 @@ public class FileHistoryGraphGetLatestFilesTest {
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addChange("a", rev(6), Collections.singleton(rev(5)));
         g.addDeletion("a", rev(20));
-        g.addCopy("a", "b", rev(5), rev(23));
-        g.addCopy("b", "c", rev(23), rev(24));
+        g.addCopy("a", rev(5), "b", rev(23));
+        g.addCopy("b", rev(23), "c", rev(24));
         assertEquals(
                 Arrays.asList(file("b", 23), file("c", 24)),
                 g.getLatestFiles(file("a", 1), false));
@@ -263,7 +263,7 @@ public class FileHistoryGraphGetLatestFilesTest {
         final IMutableFileHistoryGraph g = graph();
         g.addChange("a", rev(1), Collections.singleton(rev(0)));
         g.addChange("a/x", rev(2), Collections.singleton(rev(1)));
-        g.addCopy("a", "b", rev(10), rev(11));
+        g.addCopy("a", rev(10), "b", rev(11));
         g.addChange("a/x", rev(11), Collections.singleton(rev(10)));
         g.addChange("b/x", rev(11), Collections.singleton(rev(10)));
         g.addDeletion("a", rev(13));

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphGetLatestFilesTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphGetLatestFilesTest.java
@@ -36,226 +36,226 @@ public class FileHistoryGraphGetLatestFilesTest {
     public void testUnknownFile() {
         final IMutableFileHistoryGraph g = graph();
         assertEquals(
-                Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/a", 1)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("bcd", 42)),
-                g.getLatestFiles(file("bcd", 42), false));
+                Arrays.asList(file("/bcd", 42)),
+                g.getLatestFiles(file("/bcd", 42), false));
     }
 
     @Test
     public void testCopy() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addCopy("a", rev(5), "b", rev(6));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addCopy("/a", rev(5), "/b", rev(6));
         assertEquals(
-                Arrays.asList(file("a", 5), file("b", 6)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/a", 5), file("/b", 6)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("a", 5), file("b", 6)),
-                g.getLatestFiles(file("a", 5), false));
+                Arrays.asList(file("/a", 5), file("/b", 6)),
+                g.getLatestFiles(file("/a", 5), false));
         assertEquals(
-                Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6), false));
+                Arrays.asList(file("/a", 6)),
+                g.getLatestFiles(file("/a", 6), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false));
     }
 
     @Test
     public void testDeletion() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addDeletion("a", rev(12));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addDeletion("/a", rev(12));
         assertEquals(
-                Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/a", 1)),
+                g.getLatestFiles(file("/a", 1), false));
     }
 
     @Test
     public void testDeletionOfUnknown() {
         final IMutableFileHistoryGraph g = graph();
-        g.addDeletion("a", rev(12));
+        g.addDeletion("/a", rev(12));
         assertEquals(
-                Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/a", 1)),
+                g.getLatestFiles(file("/a", 1), false));
     }
 
     @Test
     public void testMoveOneWay() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addCopy("a", rev(5), "b", rev(6));
-        g.addDeletion("a", rev(6));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addCopy("/a", rev(5), "/b", rev(6));
+        g.addDeletion("/a", rev(6));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 5), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/a", 5), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false));
     }
 
     @Test
     public void testMoveOtherWay() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addDeletion("a", rev(6));
-        g.addCopy("a", rev(5), "b", rev(6));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addDeletion("/a", rev(6));
+        g.addCopy("/a", rev(5), "/b", rev(6));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("a", 5), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/a", 5), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false));
     }
 
     @Test
     public void testMoveWithMultipleCopies() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)) );
-        g.addCopy("a", rev(5), "b", rev(6));
-        g.addDeletion("a", rev(6));
-        g.addCopy("a", rev(5), "c", rev(6));
-        g.addCopy("a", rev(5), "d", rev(6));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)) );
+        g.addCopy("/a", rev(5), "/b", rev(6));
+        g.addDeletion("/a", rev(6));
+        g.addCopy("/a", rev(5), "/c", rev(6));
+        g.addCopy("/a", rev(5), "/d", rev(6));
         assertEquals(
-                Arrays.asList(file("b", 6), file("c", 6), file("d", 6)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/b", 6), file("/c", 6), file("/d", 6)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("b", 6), file("c", 6), file("d", 6)),
-                g.getLatestFiles(file("a", 5), false));
+                Arrays.asList(file("/b", 6), file("/c", 6), file("/d", 6)),
+                g.getLatestFiles(file("/a", 5), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false));
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false));
         assertEquals(
-                Arrays.asList(file("c", 6)),
-                g.getLatestFiles(file("c", 6), false));
+                Arrays.asList(file("/c", 6)),
+                g.getLatestFiles(file("/c", 6), false));
         assertEquals(
-                Arrays.asList(file("d", 6)),
-                g.getLatestFiles(file("d", 6), false));
+                Arrays.asList(file("/d", 6)),
+                g.getLatestFiles(file("/d", 6), false));
     }
 
     @Test
     public void testMoveMultipleTimes() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addDeletion("a", rev(11));
-        g.addCopy("a", rev(10), "b", rev(11));
-        g.addDeletion("b", rev(21));
-        g.addCopy("b", rev(20), "c", rev(21));
-        g.addDeletion("c", rev(31));
-        g.addCopy("c", rev(30), "d", rev(31));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addDeletion("/a", rev(11));
+        g.addCopy("/a", rev(10), "/b", rev(11));
+        g.addDeletion("/b", rev(21));
+        g.addCopy("/b", rev(20), "/c", rev(21));
+        g.addDeletion("/c", rev(31));
+        g.addCopy("/c", rev(30), "/d", rev(31));
 
         assertEquals(
-                Arrays.asList(file("d", 31)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/d", 31)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("d", 31)),
-                g.getLatestFiles(file("a", 10), false));
+                Arrays.asList(file("/d", 31)),
+                g.getLatestFiles(file("/a", 10), false));
         assertEquals(
-                Arrays.asList(file("a", 11)),
-                g.getLatestFiles(file("a", 11), false));
+                Arrays.asList(file("/a", 11)),
+                g.getLatestFiles(file("/a", 11), false));
     }
 
     @Test
     public void testMoveAndDeleteAfterwards() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addDeletion("a", rev(11));
-        g.addCopy("a", rev(10), "b", rev(11));
-        g.addDeletion("b", rev(21));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addDeletion("/a", rev(11));
+        g.addCopy("/a", rev(10), "/b", rev(11));
+        g.addDeletion("/b", rev(21));
 
         assertEquals(
-                Arrays.asList(file("b", 11)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/b", 11)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("b", 11)),
-                g.getLatestFiles(file("a", 10), false));
+                Arrays.asList(file("/b", 11)),
+                g.getLatestFiles(file("/a", 10), false));
     }
 
     @Test
     public void testMoveAndDeleteAfterwardsStartWithDeletion() {
         final IMutableFileHistoryGraph g = graph();
-        g.addDeletion("a", rev(11));
-        g.addCopy("a", rev(10), "b", rev(11));
-        g.addDeletion("b", rev(21));
+        g.addDeletion("/a", rev(11));
+        g.addCopy("/a", rev(10), "/b", rev(11));
+        g.addDeletion("/b", rev(21));
 
         assertEquals(
-                Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/a", 1)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("a", 10)), // (a,10)-->(a,11) is not known as the graph starts at revision 11
-                g.getLatestFiles(file("a", 10), false));
+                Arrays.asList(file("/a", 10)), // (a,10)-->(a,11) is not known as the graph starts at revision 11
+                g.getLatestFiles(file("/a", 10), false));
     }
 
     @Test
     public void testCopyWithRevisionSkip() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addChange("a", rev(6), Collections.singleton(rev(5)));
-        g.addDeletion("a", rev(20));
-        g.addCopy("a", rev(5), "b", rev(23));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addChange("/a", rev(6), Collections.singleton(rev(5)));
+        g.addDeletion("/a", rev(20));
+        g.addCopy("/a", rev(5), "/b", rev(23));
         assertEquals(
-                Arrays.asList(file("b", 23)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/b", 23)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6), false));
+                Arrays.asList(file("/a", 6)),
+                g.getLatestFiles(file("/a", 6), false));
         assertEquals(
-                Arrays.asList(file("b", 23)),
-                g.getLatestFiles(file("b", 23), false));
+                Arrays.asList(file("/b", 23)),
+                g.getLatestFiles(file("/b", 23), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false)); //b@6 is non-existing
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false)); //b@6 is non-existing
     }
 
     @Test
     public void testCopyWithRevisionSkipStartWithDeletion() {
         final IMutableFileHistoryGraph g = graph();
-        g.addDeletion("a", rev(20));
-        g.addCopy("a", rev(5), "b", rev(23));
+        g.addDeletion("/a", rev(20));
+        g.addCopy("/a", rev(5), "/b", rev(23));
         assertEquals(
-                Arrays.asList(file("a", 1)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/a", 1)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("a", 5), file("b", 23)),
-                g.getLatestFiles(file("a", 5), false));
+                Arrays.asList(file("/a", 5), file("/b", 23)),
+                g.getLatestFiles(file("/a", 5), false));
         assertEquals(
-                Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6), false));
+                Arrays.asList(file("/a", 6)),
+                g.getLatestFiles(file("/a", 6), false));
         assertEquals(
-                Arrays.asList(file("b", 23)),
-                g.getLatestFiles(file("b", 23), false));
+                Arrays.asList(file("/b", 23)),
+                g.getLatestFiles(file("/b", 23), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false)); //b@6 is non-existing
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false)); //b@6 is non-existing
     }
 
     @Test
     public void testCopyMultipleTimesWithRevisionSkip() {
         final IMutableFileHistoryGraph g = graph();
-        g.addChange("a", rev(1), Collections.singleton(rev(0)));
-        g.addChange("a", rev(6), Collections.singleton(rev(5)));
-        g.addDeletion("a", rev(20));
-        g.addCopy("a", rev(5), "b", rev(23));
-        g.addCopy("b", rev(23), "c", rev(24));
+        g.addChange("/a", rev(1), Collections.singleton(rev(0)));
+        g.addChange("/a", rev(6), Collections.singleton(rev(5)));
+        g.addDeletion("/a", rev(20));
+        g.addCopy("/a", rev(5), "/b", rev(23));
+        g.addCopy("/b", rev(23), "/c", rev(24));
         assertEquals(
-                Arrays.asList(file("b", 23), file("c", 24)),
-                g.getLatestFiles(file("a", 1), false));
+                Arrays.asList(file("/b", 23), file("/c", 24)),
+                g.getLatestFiles(file("/a", 1), false));
         assertEquals(
-                Arrays.asList(file("a", 6)),
-                g.getLatestFiles(file("a", 6), false));
+                Arrays.asList(file("/a", 6)),
+                g.getLatestFiles(file("/a", 6), false));
         assertEquals(
-                Arrays.asList(file("b", 23), file("c", 24)),
-                g.getLatestFiles(file("b", 23), false));
+                Arrays.asList(file("/b", 23), file("/c", 24)),
+                g.getLatestFiles(file("/b", 23), false));
         assertEquals(
-                Arrays.asList(file("b", 6)),
-                g.getLatestFiles(file("b", 6), false)); //b@6 is non-existing
+                Arrays.asList(file("/b", 6)),
+                g.getLatestFiles(file("/b", 6), false)); //b@6 is non-existing
     }
 
     @Test

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
@@ -893,7 +893,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNode = g.getNodeFor(aRevPrev);
         assertEquals(aRevPrev, aNode.getFile());
@@ -943,7 +944,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNodePrev = g.getNodeFor(aRevPrev);
         assertEquals(aRevPrev, aNodePrev.getFile());
@@ -985,7 +987,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addDeletion(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addAddition(xRevReplaced.getPath(), xRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNode = g.getNodeFor(aRevPrev);
@@ -1067,7 +1070,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", new TestRepoRevision(repo, 2L));
 
-        g.addReplacement(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addDeletion(xRevReplaced.getPath(), xRevReplaced.getRevision());
+        g.addAddition(xRevReplaced.getPath(), xRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aNodeReplaced = g.getNodeFor(aRevReplaced);
@@ -2132,9 +2136,10 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
         g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
-        g.addReplacement(bRevReplaced.getPath(), bRevReplaced.getRevision(),
-                bRevOrig.getPath(), bRevOrig.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2212,9 +2217,10 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
         g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addReplacement(aRevReplaced.getPath(), aRevReplaced.getRevision());
-        g.addReplacement(bRevReplaced.getPath(), bRevReplaced.getRevision(),
-                bRevOrig.getPath(), bRevOrig.getRevision());
+        g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
+        g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/FileHistoryGraphTest.java
@@ -705,7 +705,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b/y", trunk3Rev.getRevision());
 
-        g.addCopy(aRev2.getPath(), bRevOrig.getPath(), aRev2.getRevision(), bRevOrig.getRevision());
+        g.addCopy(aRev2.getPath(), aRev2.getRevision(), bRevOrig.getPath(), bRevOrig.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final IRevisionedFile trunk4Rev =
@@ -1368,7 +1368,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1417,7 +1417,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
         g.addChange(aRevCopy.getPath(), aRevCopy.getRevision(), Collections.singleton(aRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -1479,8 +1479,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy2 =
                 ChangestructureFactory.createFileInRevision("/trunk/c", new TestRepoRevision(repo, 5L));
 
-        g.addCopy(aRevChanged.getPath(), aRevCopy.getPath(), aRevChanged.getRevision(), aRevCopy.getRevision());
-        g.addCopy(aRevSource2.getPath(), aRevCopy2.getPath(), aRevSource2.getRevision(), aRevCopy2.getRevision());
+        g.addCopy(aRevChanged.getPath(), aRevChanged.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
+        g.addCopy(aRevSource2.getPath(), aRevSource2.getRevision(), aRevCopy2.getPath(), aRevCopy2.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1543,7 +1543,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -1602,7 +1602,7 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/b", new TestRepoRevision(repo, 2L));
 
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
-        g.addCopy(aRevOrig.getPath(), aRevCopy.getPath(), aRevOrig.getRevision(), aRevCopy.getRevision());
+        g.addCopy(aRevOrig.getPath(), aRevOrig.getRevision(), aRevCopy.getPath(), aRevCopy.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1662,7 +1662,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1720,7 +1720,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y", new TestRepoRevision(repo, 3L));
 
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -1782,7 +1782,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", trunkRev.getRevision());
 
-        g.addCopy(trunkRevOrig.getPath(), xRev.getPath(), trunkRevOrig.getRevision(), xRev.getRevision());
+        g.addCopy(trunkRevOrig.getPath(), trunkRevOrig.getRevision(), xRev.getPath(), xRev.getRevision());
 
         final ProxyableFileHistoryNode trunkOrigNode = g.getNodeFor(trunkRevOrig);
         assertEquals(trunkRevOrig, trunkOrigNode.getFile());
@@ -1870,7 +1870,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/x/a", trunkRev.getRevision());
 
-        g.addCopy(oldTrunkRev.getPath(), xRev.getPath(), oldTrunkRev.getRevision(), xRev.getRevision());
+        g.addCopy(oldTrunkRev.getPath(), oldTrunkRev.getRevision(), xRev.getPath(), xRev.getRevision());
 
         final ProxyableFileHistoryNode trunkCopySourceNode = g.getNodeFor(oldTrunkRev);
         assertEquals(oldTrunkRev, trunkCopySourceNode.getFile());
@@ -1935,7 +1935,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final IRevisionedFile aRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
@@ -1978,7 +1978,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile yRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y", new TestRepoRevision(repo, 2L));
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final IRevisionedFile aRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
@@ -2028,7 +2028,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevDel =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2080,7 +2080,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevDel =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevDel.getPath(), aRevDel.getRevision());
 
         final ProxyableFileHistoryNode aNode = g.getNodeFor(aRevOrig);
@@ -2135,11 +2135,11 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRevReplaced.getPath(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2216,11 +2216,11 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRevReplaced =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addAddition(aRevReplaced.getPath(), aRevReplaced.getRevision());
         g.addDeletion(bRevReplaced.getPath(), bRevReplaced.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRevReplaced.getPath(), bRevOrig.getRevision(), bRevReplaced.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRevReplaced.getPath(), bRevReplaced.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2292,7 +2292,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevChanged =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addChange(aRevChanged.getPath(), aRevChanged.getRevision(), Collections.singleton(aRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2344,7 +2344,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevChanged =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addChange(aRevChanged.getPath(), aRevChanged.getRevision(), Collections.singleton(xRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2398,7 +2398,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevChanged =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRevChanged.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addChange(aRevChanged.getPath(), aRevChanged.getRevision(), Collections.singleton(yRev.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2458,8 +2458,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());
@@ -2528,8 +2528,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
 
         final ProxyableFileHistoryNode bOrigNode = g.getNodeFor(bRevOrig);
         assertEquals(bRevOrig, bOrigNode.getFile());
@@ -2583,8 +2583,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", new TestRepoRevision(repo, 3L));
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
 
         final ProxyableFileHistoryNode bOrigNode = g.getNodeFor(bRevOrig);
         assertEquals(bRevOrig, bOrigNode.getFile());
@@ -2649,8 +2649,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
         g.addChange(bRev.getPath(), bRev.getRevision(), Collections.singleton(bRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2720,8 +2720,8 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile bRev =
                 ChangestructureFactory.createFileInRevision("/trunk/y/b", yRev.getRevision());
 
-        g.addCopy(xRevOrig.getPath(), yRev.getPath(), xRevOrig.getRevision(), yRev.getRevision());
-        g.addCopy(bRevOrig.getPath(), bRev.getPath(), bRevOrig.getRevision(), bRev.getRevision());
+        g.addCopy(xRevOrig.getPath(), xRevOrig.getRevision(), yRev.getPath(), yRev.getRevision());
+        g.addCopy(bRevOrig.getPath(), bRevOrig.getRevision(), bRev.getPath(), bRev.getRevision());
         g.addChange(bRev.getPath(), bRev.getRevision(), Collections.singleton(bRevOrig.getRevision()));
 
         final ProxyableFileHistoryNode bOrigNode = g.getNodeFor(bRevOrig);
@@ -2779,7 +2779,7 @@ public final class FileHistoryGraphTest {
         final IRevisionedFile aRevCopy =
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
         g.addDeletion(xRevDel.getPath(), xRevDel.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
@@ -2857,7 +2857,7 @@ public final class FileHistoryGraphTest {
                 ChangestructureFactory.createFileInRevision("/trunk/y/a", yRev.getRevision());
 
         g.addDeletion(xRevDel.getPath(), xRevDel.getRevision());
-        g.addCopy(xRev.getPath(), yRev.getPath(), xRev.getRevision(), yRev.getRevision());
+        g.addCopy(xRev.getPath(), xRev.getRevision(), yRev.getPath(), yRev.getRevision());
 
         final ProxyableFileHistoryNode aOrigNode = g.getNodeFor(aRevOrig);
         assertEquals(aRevOrig, aOrigNode.getFile());

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
@@ -390,7 +390,7 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalCopyOfLatestRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/e.txt", this.rev(2), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(2), "/dir1/dir2/e.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -417,7 +417,7 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalCopyOfOlderRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/e.txt", this.rev(1), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(1), "/dir1/dir2/e.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(1)));
@@ -518,7 +518,7 @@ public class VirtualFileHistoryGraphTest {
     public void testLocalReplacementByCopyOfLatestRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
         localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(2), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(2), "/dir1/dir2/c.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -555,7 +555,7 @@ public class VirtualFileHistoryGraphTest {
     public void testLocalReplacementByCopyOfOlderRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
         localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
-        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(1), this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", this.rev(1), "/dir1/dir2/c.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(1)));

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/model/changestructure/VirtualFileHistoryGraphTest.java
@@ -78,7 +78,8 @@ public class VirtualFileHistoryGraphTest {
         // revision 2
         this.remoteFileHistoryGraph.addChange("/dir1/dir2/a.txt", this.rev(2), Collections.singleton(this.rev(1)));
         this.remoteFileHistoryGraph.addDeletion("/dir1/dir2/b.txt", this.rev(2));
-        this.remoteFileHistoryGraph.addReplacement("/dir1/dir2/c.txt", this.rev(2));
+        this.remoteFileHistoryGraph.addDeletion("/dir1/dir2/c.txt", this.rev(2));
+        this.remoteFileHistoryGraph.addAddition("/dir1/dir2/c.txt", this.rev(2));
     }
 
     @Test
@@ -454,9 +455,12 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalReplacement() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addReplacement("/dir1/dir2/a.txt", this.localRev());
-        localGraph.addReplacement("/dir1/dir2/c.txt", this.localRev());
-        localGraph.addReplacement("/dir1/dir2/d.txt", this.localRev());
+        localGraph.addDeletion("/dir1/dir2/a.txt", this.localRev());
+        localGraph.addAddition("/dir1/dir2/a.txt", this.localRev());
+        localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addAddition("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addDeletion("/dir1/dir2/d.txt", this.localRev());
+        localGraph.addAddition("/dir1/dir2/d.txt", this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -513,7 +517,8 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalReplacementByCopyOfLatestRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addReplacement("/dir1/dir2/c.txt", this.localRev(), "/dir1/dir2/a.txt", this.rev(2));
+        localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(2), this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR2 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(2)));
@@ -549,7 +554,8 @@ public class VirtualFileHistoryGraphTest {
     @Test
     public void testLocalReplacementByCopyOfOlderRevision() {
         final IMutableFileHistoryGraph localGraph = graph();
-        localGraph.addReplacement("/dir1/dir2/c.txt", this.localRev(), "/dir1/dir2/a.txt", this.rev(1));
+        localGraph.addDeletion("/dir1/dir2/c.txt", this.localRev());
+        localGraph.addCopy("/dir1/dir2/a.txt", "/dir1/dir2/c.txt", this.rev(1), this.localRev());
         this.virtualFileHistoryGraph.setLocalFileHistoryGraph(localGraph);
 
         final IFileHistoryNode aNodeR1 = this.virtualFileHistoryGraph.getNodeFor(this.file("/dir1/dir2/a.txt", this.rev(1)));


### PR DESCRIPTION
This pull request fixes a long-standing bug when an entry is added and deleted/replaced in the same commit, which can happen if a parent directory is added as a copy and then one of its (direct or indirect) children is deleted or replaced.

This pull request is based on pull request #67.