### PR TITLE
Requests to Jira can be authorized with OAuth 2.0 bearer tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ CoRT is usually configure for a whole team. Therefore, it has an XML configurati
 
 - The settings dialog can be found under "Window -> Preferences -> Reviewtool". You need to reference a configuration file there.
 - The configuration file can contain placeholders, for example for user names. These need to be configured in the settings dialog, too.
+- If a placeholder starts with the prefix "env." (i. e. "${env.USERNAME}"), the placeholder will be replaced with the value of a environment variable (environment variable "USERNAME" in this case).
 - Two examples for configuration files can be found in the repository root ("testconfig1.xml" and "testconfig2.xml"). You need to adjust them for your specific situation.
 - There is not much documentation for the config format at the moment. If you want to get into the details, have a look at the various subclasses of de.setsoftware.reviewtool.config.IConfigurator from the ...core project.
 

--- a/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/config/ConfigurationInterpreter.java
+++ b/de.setsoftware.reviewtool.core/src/de/setsoftware/reviewtool/config/ConfigurationInterpreter.java
@@ -167,11 +167,22 @@ public class ConfigurationInterpreter {
                 ret.append(parts.get(i));
             } else {
                 final String paramName = parts.get(i);
-                final String paramValue = paramValues.get(paramName);
-                if (paramValue == null) {
-                    throw new ReviewtoolException("Value for user specific parameter " + paramName + " missing.");
+                if (paramName.startsWith("env.")) {
+                    final String envVariableName = paramName.substring(4);
+                    final String paramValue = System.getenv(envVariableName);
+                    if (paramValue == null) {
+                        throw new ReviewtoolException(
+                                "Environment variable " + envVariableName
+                                + " is not set (reqired for parameter " + paramName + ")");
+                    }
+                    ret.append(paramValue);
+                } else {
+                    final String paramValue = paramValues.get(paramName);
+                    if (paramValue == null) {
+                        throw new ReviewtoolException("Value for user specific parameter " + paramName + " missing.");
+                    }
+                    ret.append(paramValue);
                 }
-                ret.append(paramValue);
             }
         }
         return ret.toString();

--- a/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/config/ConfigurationInterpreterTest.java
+++ b/de.setsoftware.reviewtool.tests/src/de/setsoftware/reviewtool/config/ConfigurationInterpreterTest.java
@@ -195,4 +195,38 @@ public class ConfigurationInterpreterTest {
         }
     }
 
+    @Test
+    public void testAttributeFromEnvironmentVariable() throws Exception {
+        final Document config = load(
+                "<reviewToolConfig>"
+                        + "  <someElement att2=\"${env.PATH}\" />"
+                        + "</reviewToolConfig>");
+
+        final Map<String, String> paramValues = new HashMap<>();
+
+        final ConfigurationInterpreter i = new ConfigurationInterpreter();
+        i.configure(config, paramValues, new TestConfigurable());
+
+        assertEquals(System.getenv().get("PATH"), paramValues.get("PATH"));
+    }
+
+    @Test
+    public void testAttributeFromMissingEnvironmentVariable() throws Exception {
+        final Document config = load(
+                "<reviewToolConfig>"
+                        + "  <someElement att2=\"${env.FOOBA}\" />"
+                        + "</reviewToolConfig>");
+
+        final Map<String, String> paramValues = new HashMap<>();
+
+        final ConfigurationInterpreter i = new ConfigurationInterpreter();
+
+        try {
+            i.configure(config, paramValues, new TestConfigurable());
+            fail("Exception expected because of unknown environment variable");
+        } catch (final ReviewtoolException e) {
+            assertTrue("wrong exception message: " + e.getMessage(), e.getMessage().contains("FOOBA"));
+        }
+
+    }
 }

--- a/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/BearerTokenProvider.java
+++ b/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/BearerTokenProvider.java
@@ -1,0 +1,91 @@
+package de.setsoftware.reviewtool.ticketconnectors.jira;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+
+/**
+ * Utility class that provides/creates a bearer token when using OAuth 2.0.
+ */
+final class BearerTokenProvider {
+
+    private BearerTokenProvider() {
+    }
+
+    /**
+     * Creates a bearer token.
+     */
+    final static String createBearerToken(
+            final String oauthIssuer,
+            final String oauthAudience,
+            final String oauthClientID,
+            final String oauthClientSecret) throws IOException {
+
+        final String issuerUri = oauthIssuer + "oauth/token";
+        final HttpURLConnection c = (HttpURLConnection) new URL(issuerUri).openConnection();
+
+        c.setRequestMethod("POST");
+        c.addRequestProperty("Content-Type", "application/json");
+        c.setDoOutput(true);
+        c.connect();
+
+        final JsonObject data = new JsonObject();
+        data.add("client_id", oauthClientID);
+        data.add("client_secret", oauthClientSecret);
+        data.add("audience", oauthAudience);
+        data.add("grant_type", "client_credentials");
+
+        try (OutputStream out = c.getOutputStream()) {
+            out.write(data.toString().getBytes(StandardCharsets.UTF_8));
+        }
+
+        try (
+                final InputStream input = c.getInputStream();
+                final InputStreamReader reader = new InputStreamReader(input, StandardCharsets.UTF_8);) {
+
+            final JsonObject json = Json.parse(reader).asObject();
+            final String bearerToken = json.getString("access_token", null); //$NON-NLS-1$
+
+            final String[] tokenParts = bearerToken.split("\\."); //$NON-NLS-1$
+            if (tokenParts.length != 3) {
+                throw new IOException("Received invalid bearer token"); //$NON-NLS-1$
+            }
+
+            final JsonObject jsonHeader = Json.parse(decodeBase64EncodedString(tokenParts[0])).asObject();
+            final String type = jsonHeader.get("typ").asString(); //$NON-NLS-1$
+            if (!type.equals("JWT")) { //$NON-NLS-1$
+                throw new IOException("JSON web token expected: " + type); //$NON-NLS-1$
+            }
+
+            final JsonObject jsonData = Json.parse(decodeBase64EncodedString(tokenParts[1])).asObject();
+            final String jwtAudience = jsonData.get("aud").asString(); //$NON-NLS-1$
+            if (!jwtAudience.equals(oauthAudience)) {
+                throw new IOException("Invalid audience in token: " + jwtAudience); //$NON-NLS-1$
+            }
+
+            final String jwtIssuer = jsonData.get("iss").asString(); //$NON-NLS-1$
+            if (!jwtIssuer.equals(oauthIssuer)) {
+                throw new IOException("Invalid issuer in token: " + jwtIssuer); //$NON-NLS-1$
+            }
+
+            return bearerToken;
+        } finally {
+            c.disconnect();
+        }
+    }
+
+    /**
+     * Decodes a Base64 encoded String.
+     */
+    private static String decodeBase64EncodedString(final String input) {
+        return new String(Base64.getUrlDecoder().decode(input), StandardCharsets.ISO_8859_1);
+    }
+}

--- a/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/BearerTokenProvider.java
+++ b/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/BearerTokenProvider.java
@@ -23,7 +23,7 @@ final class BearerTokenProvider {
     /**
      * Creates a bearer token.
      */
-    final static String createBearerToken(
+    static final String createBearerToken(
             final String oauthIssuer,
             final String oauthAudience,
             final String oauthClientID,

--- a/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/JiraConnectorConfigurator.java
+++ b/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/JiraConnectorConfigurator.java
@@ -45,7 +45,11 @@ public class JiraConnectorConfigurator implements IConfigurator {
                 xml.getAttribute("user"),
                 xml.getAttribute("password"),
                 linkSettings,
-                this.toFile(xml.getAttribute("cookieFile")));
+                this.toFile(xml.getAttribute("cookieFile")),
+                xml.getAttribute("oauthIssuer"),
+                xml.getAttribute("oauthAudience"),
+                xml.getAttribute("oauthClientID"),
+                xml.getAttribute("oauthClientSecret"));
         final NodeList filters = xml.getElementsByTagName("filter");
         for (int i = 0; i < filters.getLength(); i++) {
             final Element filter = (Element) filters.item(i);

--- a/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/JiraPersistence.java
+++ b/de.setsoftware.reviewtool.ticketconnectors.jira/src/de/setsoftware/reviewtool/ticketconnectors/jira/JiraPersistence.java
@@ -607,7 +607,7 @@ public class JiraPersistence implements ITicketConnector {
                 this.oauthClientSecret);
 
         return "bearertoken=" + bearerToken;
-     }
+    }
 
     private void flushErrorStream(final HttpURLConnection c) throws IOException {
         try (final InputStream s = c.getErrorStream()) {


### PR DESCRIPTION
This pull requests adds two features to CoRT:

Requests to Jira can be authorized with OAuth 2.0 bearer tokens. This is useful if Jira is hosed behind a reverse proxy and the reverse proxy acts like a "security gate" in front of Jira. This is a common practice if the reverse proxy utilizes a  Identity-as-a-Service (IDaaS) like Auth0, Okta or Keycloak.

For this feature the `jiraTicketStore` element in the configuration file needs to be extended by the attributes `oauthIssuer`, `oauthAudience`, `oauthClientID `and `oauthClientSecret`. If the attribute `oauthIssuer` is not specified the value of the attribute `url` is used as a fallback.

The second feature is the ability to use environment variables in the configuration file. If a placeholder in the configuration file starts with the prefix `env.` then the placeholder is replaced with the value of the corresponding environment variable. I. e. the placeholder `${env.USERNAME}` would be replaced by the environment variable `USERNAME`.